### PR TITLE
Build a docker image containing VSCode

### DIFF
--- a/frontend/vscode/build/Dockerfile
+++ b/frontend/vscode/build/Dockerfile
@@ -1,0 +1,17 @@
+# Container for building the vscode web assets and publishing them in a container.
+# This is based off of the devcontaienr for vscode.
+# https://github.com/microsoft/vscode/blob/main/.devcontainer/Dockerfile
+# The main difference is that we don't install vscode in the container; i.e. we don't call the install-vscode.sh script.
+FROM mcr.microsoft.com/devcontainers/typescript-node:18-bookworm
+
+# Not sure why this is needed since its not in the dev container.
+RUN apt-get update -y && \
+  apt-get install -y libxkbfile-dev
+
+# N.B. If we switch to user node here we won't have permission to create the vscode directory.
+# Should we create a "/workspace" dir and do everything in there and give it permission vscode?
+# USER node
+RUN npm install -g node-gyp
+
+COPY /frontend/vscode/build/build.sh /build.sh
+RUN /build.sh

--- a/frontend/vscode/build/README.md
+++ b/frontend/vscode/build/README.md
@@ -1,0 +1,4 @@
+# Build a vscode image
+
+This builds a docker image containing the compiled version of vscode.
+This is the fist step of the build process.

--- a/frontend/vscode/build/build.sh
+++ b/frontend/vscode/build/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Script to build vscode
+set -ex
+
+git clone https://github.com/microsoft/vscode.git /vscode
+
+cd /vscode
+git checkout 1.85.0
+
+# Call yarn to initialize the yarn project
+yarn
+yarn compile-build
+yarn compile-extensions-build
+node --max_old_space_size=4095 ./node_modules/gulp/bin/gulp.js compile-extension-media
+yarn minify-vscode-reh-web

--- a/frontend/vscode/build/image-pod.yaml
+++ b/frontend/vscode/build/image-pod.yaml
@@ -1,0 +1,24 @@
+# This pod is useful for interactively testing out the script to build the image
+apiVersion: v1
+kind: Pod
+metadata:
+  name: image-pod
+spec:
+  securityContext:
+    runAsUser: 0
+  containers:
+    - image: mcr.microsoft.com/devcontainers/typescript-node:18-bookworm
+      name: main
+      command:
+        - tail
+        - -f
+        - /dev/null
+      resources:
+        # Minimize the footprint to keep cost low
+        limits:
+          cpu: "8"
+          memory: 16Gi
+        requests:
+          cpu: "8"
+          memory: 16Gi
+          ephemeral-storage:  10Gi

--- a/frontend/vscode/build/image.yaml
+++ b/frontend/vscode/build/image.yaml
@@ -1,0 +1,19 @@
+kind: Image
+apiVersion: hydros.dev/v1alpha1
+metadata:
+  name: vscode
+  namespace: foyle
+  labels:
+    env: dev
+spec:
+  image: us-west1-docker.pkg.dev/foyle-public/images/vscode
+  source:
+    - uri: https://github.com/jlewi/foyle.git
+      mappings:
+        - src: "/frontend/vscode/build/**/*"
+  builder:
+    gcb:
+      project: foyle-public
+      bucket : builds-foyle-public
+      machineType: 'E2_HIGHCPU_32'
+      dockerfile: /frontend/vscode/build/Dockerfile


### PR DESCRIPTION
* This is the first step in building and distributing vscode
* We build vscode in a container and then push an image containing all of the compiled assets

* In a second step we will build a container from this one that only contains the assets we want to distribute. This will make it easier/faster to iterate if we find we are missing assets. Building vscode is quite slow.