### PR TITLE
Implement generate in the front end

### DIFF
--- a/app/pkg/agent/agent.go
+++ b/app/pkg/agent/agent.go
@@ -1,0 +1,24 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/jlewi/foyle/protos/go/foyle/v1alpha1"
+)
+
+// Agent is the agent.
+type Agent struct {
+	v1alpha1.UnimplementedGenerateServiceServer
+}
+
+func (e *Agent) Generate(context.Context, *v1alpha1.GenerateRequest) (*v1alpha1.GenerateResponse, error) {
+	resp := &v1alpha1.GenerateResponse{
+		Blocks: []*v1alpha1.Block{
+			{
+				Kind:     v1alpha1.BlockKind_MARKUP,
+				Contents: "Hello From The Foyle Server! Your generate request was recieved.",
+			},
+		},
+	}
+	return resp, nil
+}

--- a/frontend/foyle/README.md
+++ b/frontend/foyle/README.md
@@ -4,6 +4,8 @@ This the vscode extension that is the frontend for foyle.
 
 The extension was initialized using the [vscode extension generator](https://code.visualstudio.com/api/get-started/your-first-extension).
 
+see [vscode_apis.md](vscode_apis.md) for explanation of the vscode apis.
+
 ## Developer Guide
 
 * In vscode for web you can go to the extensions tab and search for "@builtin" to see if the extension is loaded

--- a/frontend/foyle/package.json
+++ b/frontend/foyle/package.json
@@ -37,10 +37,15 @@
     "configuration": {
       "title": "Foyle",
       "properties": {
-        "foyle-notebook.address": {
+        "foyle-notebook.agent-address": {
           "type": "string",
           "default": "http://localhost:8080",
-          "description": "The address of the Foyle. This should in the form {protocol}://{host}:{port}."
+          "description": "The address of the Foyle Agent. The agent generates completions. This should in the form {protocol}://{host}:{port}."
+        },
+        "foyle-notebook.executor-address": {
+          "type": "string",
+          "default": "http://localhost:8080",
+          "description": "The address of the Foyle Executor. The executor executes shell commands. This should in the form {protocol}://{host}:{port}."
         }
       }
     },

--- a/frontend/foyle/src/web/client.ts
+++ b/frontend/foyle/src/web/client.ts
@@ -8,25 +8,16 @@ import { extName } from "./constants";
 // TODO(jeremy): One of 
 export class FoyleClient {
 
-    // TODO(jeremy): How do we deal with the async nature of the fetch call?
-    // We should probably return a promise.
+    // Execute a request.
     public Execute(request: agentpb.ExecuteRequest): Promise<agentpb.ExecuteResponse> {
-         // getConfiguration takes a section name.
-         const config = vscode.workspace.getConfiguration(extName);
-         // Include a default so that address is always well defined
-         const address = config.get<string>("address", "http://localhost:8080"); 
-        const resp = new agentpb.ExecuteResponse();
-        const o = new docpb.BlockOutput();
-        const i = new docpb.BlockOutputItem();
-        i.textData = "some output";
-        o.items = [i];
-        resp.outputs = [
-            o,  
-        ];
+        // getConfiguration takes a section name.
+        const config = vscode.workspace.getConfiguration(extName);
+        // Include a default so that address is always well defined
+        const address = config.get<string>("executor-address", "http://localhost:8080"); 
 
         return fetch(address + "/api/v1alpha1/execute", {
             method: 'POST',
-            body: resp.toJsonString(),
+            body: request.toJsonString(),
             headers: { 'Content-Type': 'application/json' },
         })
         .then(response => response.json())
@@ -34,6 +25,46 @@ export class FoyleClient {
             const resp = agentpb.ExecuteResponse.fromJson(data);
             return resp;
         });                
-    }    
+    } 
+
+    // generate a completion.
+    public generate(request: agentpb.GenerateRequest): Promise<agentpb.GenerateResponse> {
+        // getConfiguration takes a section name.
+        const config = vscode.workspace.getConfiguration(extName);
+        // Include a default so that address is always well defined
+        const address = config.get<string>("agent-address", "http://localhost:8080"); 
+        
+        return fetch(address + "/api/v1alpha1/generate", {
+           method: 'POST',
+           body: request.toJsonString(),
+           headers: { 'Content-Type': 'application/json' },
+       })
+       .then(response => response.json())
+       .then(data => {
+           const resp = agentpb.GenerateResponse.fromJson(data);
+           return resp;
+       });                
+   }    
 }
 
+
+// getTraceID takes a list of blocks and returns the most recent traceId 
+// if there is one. 
+// Returns the empty string if there is no traceId
+export function getTraceID(blocks: docpb.Block[]): string {
+    if (blocks.length <= 0) {
+      return "";
+    }    
+    var lastBlock = blocks.at(-1);
+    if (lastBlock === undefined) {
+      return "";
+    }
+    if (lastBlock.traceIds.length === 0) {
+      return "";
+    }
+    const v = lastBlock.traceIds.at(-1);
+    if (v === undefined) {
+      return "";
+    }
+    return v;
+  }

--- a/frontend/foyle/src/web/converters.ts
+++ b/frontend/foyle/src/web/converters.ts
@@ -1,0 +1,133 @@
+// Conversion routines between the protocol buffer format and VSCode's representation of a notebook
+//
+// VSCode has two different APIs
+// 1. Data APIs (NotebookData, NotebookCellData)
+//    https://github.com/microsoft/vscode/blob/98332892fd2cb3c948ced33f542698e20c6279b9/src/vs/workbench/api/common/extHostTypes.ts#L3598
+//    * These are concrete classes
+//    * This is what the serialization uses 
+//      * i.e. Serialize.serializeNotebook passes a VSCodeNotebookData as input
+//      * The deserializer returns a VSCodeNotebookData
+//    * NotebookCellData has an interface and concrete class
+//      concrete class - https://github.com/microsoft/vscode/blob/e4595ad3998a436bbf68d32a6c59e9d49fc63e32/src/vs/workbench/api/common/extHostTypes.ts#L3668
+//      interface - https://github.com/microsoft/vscode/blob/e4595ad3998a436bbf68d32a6c59e9d49fc63e32/src/vscode-dts/vscode.proposed.notebookMime.d.ts#L10
+//
+// 2. Editor APIs (NotebookDocument, NotebookCell)
+//    * These are interfaces
+//    * These are used by the editor
+//    * To my knowledge there aren't concrete classes
+// 3. Both APIs use NotebookCellOutput, NotebookCellOutputItem
+//    * These are concrete classes
+// 4. NotebookCellData isn't compatible with the interface NotebookCell
+//    * NotebookCellData has extra fields such as index and document.
+//
+// However (NotebookCell and NotebookCellData) share the following fields:
+//    kind: NotebookCellKind
+//    metadata: [key: string];
+//    outputs: NotebookCellOutput[];
+//
+// However the differe in how the actual value is stored.
+
+// NotebookCellData uses the fields:
+//    value: string;
+//    languageId: string;
+//
+// Whereas NotebookCell uses the field:
+//   document: TextDocument;
+//
+// TextDocument has the following fields and methods for our purposes
+//   languageId: string;
+//   getText(): string;
+//
+//
+
+import * as vscode from 'vscode';
+import * as docpb from "../gen/foyle/v1alpha1/doc_pb";
+import * as metadata from "./metadata";
+import * as constants from "./constants";
+
+// cellToCellData converts a NotebookCell to a NotebookCellData.
+// NotebookCell is an interface used by the editor.
+// NotebookCellData is a concrete class.
+export function cellToCellData(cell: vscode.NotebookCell): vscode.NotebookCellData {
+  let data = new vscode.NotebookCellData(cell.kind, cell.document.getText(), cell.document.languageId);
+
+  data.metadata = cell.metadata;
+  data.outputs = [];
+  for (let o of cell.outputs) {
+    data.outputs.push(o);
+  }
+  return data;
+}
+
+// cellDataToBlock converts an instance of NotebookCellData to the Block proto.
+export function cellDataToBlock(cell: vscode.NotebookCellData): docpb.Block {
+  let block = new docpb.Block();
+  block.contents = cell.value;
+  block.language = cell.languageId;
+  if (cell.kind === vscode.NotebookCellKind.Code) {
+    block.kind = docpb.BlockKind.CODE;
+  } else {
+    block.kind = docpb.BlockKind.MARKUP;
+  }
+
+  if (cell.metadata !== undefined) {
+    metadata.setBlockFromMeta(block, cell.metadata);
+  }
+  
+  let cellOutputs: vscode.NotebookCellOutput[] = [];
+  if (cell.outputs !== undefined) {
+    cellOutputs = cell.outputs;
+  }
+  for (const output of cellOutputs) {
+    let outBlock = new docpb.BlockOutput();
+    outBlock.items = [];
+    for (const item of output.items) {
+      let outItem = new docpb.BlockOutputItem();
+      outItem.textData = new TextDecoder().decode(item.data);
+      outItem.mime = item.mime;
+      outBlock.items.push(outItem);
+    }
+    block.outputs.push(outBlock);
+  }
+
+  return block;
+}
+
+// blockToCellData converts a Block proto to a NotebookCellData.
+export function blockToCellData(block: docpb.Block): vscode.NotebookCellData {
+  let kind = vscode.NotebookCellKind.Markup;
+  if (block.kind === docpb.BlockKind.CODE) { 
+    kind = vscode.NotebookCellKind.Code;
+  }
+  let language = block.language;
+  if (language === "" && kind === vscode.NotebookCellKind.Code) {
+    // Default to the bash language
+    language = constants.bashLang;
+
+    if (language !== constants.bashLang) {
+      console.log(`Unsupported language: ${language}`);
+    }
+  }
+
+  let newCell = new vscode.NotebookCellData(
+    kind,
+    block.contents,
+    language             
+  );
+
+  newCell.metadata = metadata.getCellMetadata(block);
+  newCell.outputs = [];
+  for (let output of block.outputs) {
+    let items: vscode.NotebookCellOutputItem[] = [];
+    for (let item of output.items) {
+      if (item.textData !== "") {
+        const text = new TextEncoder().encode(item.textData);            
+        items.push(new vscode.NotebookCellOutputItem(text, item.mime));          
+      } else {
+        console.log("Unknown output type");
+      }
+    }
+    newCell.outputs.push(new vscode.NotebookCellOutput(items));
+  }
+  return newCell;
+}

--- a/frontend/foyle/src/web/extension.ts
+++ b/frontend/foyle/src/web/extension.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 import { Controller } from './controller';
 import {FoyleClient} from './client';
 import { Serializer } from './serializer';
-
+import * as generate from './generate';
 // Create a client for the backend.
 const client = new FoyleClient;
 
@@ -49,6 +49,9 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.window.showInformationMessage('Hello World from foyle in a web extension host!');
 	});
 
+	// Here's where we register the command that will generate a completion using the AI model
+	// You can set a keybinding for this command in the package.json file
+  context.subscriptions.push(vscode.commands.registerCommand("foyle.generate", generate.generateCompletion));
 	context.subscriptions.push(disposable);
 }
 

--- a/frontend/foyle/src/web/generate.ts
+++ b/frontend/foyle/src/web/generate.ts
@@ -1,0 +1,91 @@
+import * as vscode from 'vscode';
+import {FoyleClient, getTraceID} from './client';
+import * as converters from './converters';
+import * as docpb from "../gen/foyle/v1alpha1/doc_pb";
+import * as agentpb from "../gen/foyle/v1alpha1/agent_pb";
+// generateCompletion generates a completion by calling the foyle backend and then adds
+// the returned blocks to the window
+export async function generateCompletion() {
+  const editor = vscode.window.activeNotebookEditor;
+
+  if (!editor) {    
+    return;
+  }
+
+  if (editor?.selection.isEmpty) {    
+    return;
+  }
+  
+  // We subtract 1 because end is non-inclusive
+  const lastSelectedCell = editor?.selection.end - 1;
+  var lastActiveCell = editor?.notebook.cellAt(lastSelectedCell);  
+  let cells = editor?.notebook.getCells(new vscode.NotebookRange(0, editor?.notebook.cellCount));
+
+  let doc = new docpb.Doc();
+  doc.blocks = [];
+  for (let cell of cells) {
+    let block = converters.cellDataToBlock(converters.cellToCellData(cell));
+    doc.blocks.push(block);
+  }
+  
+  let client = new FoyleClient();
+
+  const request = new agentpb.GenerateRequest();
+  request.doc = doc;
+    
+
+  client.generate(request).then((response: agentpb.GenerateResponse) => {
+    var traceId = "";
+
+    traceId = getTraceID(response.blocks);
+       
+    console.log(`Generate request succeeded traceId: ${traceId}`);
+    
+    // To add the traceId to the input data we need to create a mutation
+    const traceIdEdit = createAddTraceIDMutation(lastActiveCell, traceId);
+    
+    const insertCells = addAIGeneratedCells(lastSelectedCell+1, response);
+    
+    const edit = new vscode.WorkspaceEdit();
+    const notebookUri = editor?.notebook.uri;
+    edit.set(notebookUri, [insertCells, traceIdEdit]);
+    vscode.workspace.applyEdit(edit).then((result:boolean)=>{
+      console.log(`applyedit resolved with ${result}`);
+    });
+  }).catch((error) => {
+    console.error(`Generate request failed ${error}`);
+    return;
+  });
+}
+
+// addAIGeneratedCells turns the response from the AI model into a set of cells that can be inserted into the notebook.
+// This is done by returning a mutation to add the new cells to the notebook.
+// index is the position in the notebook at which the new the new cells should be inserted.
+function addAIGeneratedCells(index: number,response: agentpb.GenerateResponse): vscode.NotebookEdit {  
+  let newCellData: vscode.NotebookCellData[] = [];
+    
+  for (let newBlock of response.blocks) {
+    const data = converters.blockToCellData(newBlock);
+    newCellData.push(data);
+  }
+
+   // Now insert the new cells at the end of the notebook
+   return  vscode.NotebookEdit.insertCells(index, newCellData);  
+}
+
+// createAddTraceIDMutation creates a notebook mutation (NotebookEdit)
+// to add a traceID to the cell metadata. This function takes care of merging
+// the traceID with any existing traceIDs.
+export function createAddTraceIDMutation(nbCell: vscode.NotebookCell, traceId: string): vscode.NotebookEdit{
+  var traces : string[] = [];
+    if (nbCell.metadata.hasOwnProperty("traceIds")) {      
+      traces = traces.concat(nbCell.metadata["traceIds"]);
+    }
+    traces.push(traceId);
+
+    const newMeta = {
+      "traceIds": traces,
+    };
+    
+    return vscode.NotebookEdit.updateCellMetadata(nbCell.index, newMeta);
+}

--- a/frontend/foyle/vscode_apis.md
+++ b/frontend/foyle/vscode_apis.md
@@ -1,0 +1,52 @@
+# VSCode Notebook APIs
+
+The VSCode notebook APIs are a bit confusing. This document is an attempt to clarify them.
+
+ Conversion routines between the protocol buffer format and VSCode's representation of a notebook
+
+ VSCode has two different APIs
+ 1. Data APIs (NotebookData, NotebookCellData)
+    https:github.com/microsoft/vscode/blob/98332892fd2cb3c948ced33f542698e20c6279b9/src/vs/workbench/api/common/extHostTypes.ts#L3598
+    * These are concrete classes
+    * This is what the serialization uses 
+      * i.e. Serialize.serializeNotebook passes a VSCodeNotebookData as input
+      * The deserializer returns a VSCodeNotebookData
+    * NotebookCellData has an interface and concrete class
+      concrete class - https:github.com/microsoft/vscode/blob/e4595ad3998a436bbf68d32a6c59e9d49fc63e32/src/vs/workbench/api/common/extHostTypes.ts#L3668
+      interface - https:github.com/microsoft/vscode/blob/e4595ad3998a436bbf68d32a6c59e9d49fc63e32/src/vscode-dts/vscode.proposed.notebookMime.d.ts#L10
+
+ 2. Editor APIs (NotebookDocument, NotebookCell)
+    * These are interfaces
+    * These are used by the editor
+    * To my knowledge there aren't concrete classes
+ 3. Both APIs use NotebookCellOutput, NotebookCellOutputItem
+    * These are concrete classes
+ 4. NotebookCellData isn't compatible with the interface NotebookCell
+    * NotebookCellData has extra fields such as index and document.
+
+ However (NotebookCell and NotebookCellData) share the following fields:
+    kind: NotebookCellKind
+    metadata: [key: string];
+    outputs: NotebookCellOutput[];
+
+ However the differe in how the actual value is stored.
+
+ NotebookCellData uses the fields:
+    value: string;
+    languageId: string;
+
+ Whereas NotebookCell uses the field:
+   document: TextDocument;
+
+ TextDocument has the following fields and methods for our purposes
+   languageId: string;
+   getText(): string;
+
+The TextDocument only appears to be used when reading cells from the editor.
+
+The mutations API vscode.NotebookEdit.insertCells uses NotebookCellData.
+
+Therefore in order to avoid repeating conversion code between VSCode Notebook classes and the protos we use the following patterns
+* We have conversion methods to/from the Block proto to NotebookCellData
+* We have conversion method from NotebookCell to NotebookCellData
+


### PR DESCRIPTION
* Add conversion routines to and from the protos to the vscode APIs
* Add doc vscode_apis.md which to explain it.
* Use separate addresses to configure the Executor and Agent service in vscode so they don't have to be colocated
* Scaffold an initial agent in the golang server to handle the requests.