### PR TITLE
Update default image registry references

### DIFF
--- a/app/pkg/config/config.go
+++ b/app/pkg/config/config.go
@@ -26,8 +26,8 @@ const (
 	appName        = "foyle"
 	ConfigDir      = "." + appName
 
-	defaultVSCodeImage = "us-west1-docker.pkg.dev/foyle-public/images/vscode-web-assets:latest"
-	defaultFoyleImage  = "us-west1-docker.pkg.dev/foyle-public/images/foyle-vscode-ext:latest"
+	defaultVSCodeImage = "ghcr.io/jlewi/vscode-web-assets:latest"
+	defaultFoyleImage  = "ghcr.io/jlewi/foyle-vscode-ext:latest"
 )
 
 // Config represents the persistent configuration data for Foyle.


### PR DESCRIPTION
This PR updates the default image registry references to point to a new location via GitHub Container Registry.