### PR TITLE
Download command should look for image based on the commit

### DIFF
--- a/app/cmd/version.go
+++ b/app/cmd/version.go
@@ -10,12 +10,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	commitNotSet = "none"
+)
+
 // These constants will be set by ldflags.
 // They can be set by goreleaser
 // https://goreleaser.com/cookbooks/using-main.version/?h=using+main.version
 var (
 	version = "dev"
-	commit  = "none"
+	commit  = commitNotSet
 	date    = "unknown"
 	builtBy = "unknown"
 )

--- a/app/pkg/assets/manager_test.go
+++ b/app/pkg/assets/manager_test.go
@@ -2,12 +2,46 @@ package assets
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/jlewi/foyle/app/pkg/config"
 	"go.uber.org/zap"
 )
+
+func Test_ResolveImage(t *testing.T) {
+	type testCase struct {
+		image    string
+		tag      string
+		expected string
+	}
+
+	cases := []testCase{
+		{
+			image:    "ghcr.io/jlewi/vscode-web-assets",
+			tag:      "1234",
+			expected: "ghcr.io/jlewi/vscode-web-assets:1234",
+		},
+		{
+			image:    "ghcr.io/jlewi/vscode-web-assets:abcd",
+			tag:      "1234",
+			expected: "ghcr.io/jlewi/vscode-web-assets:abcd",
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			actual, err := resolveTag(c.image, c.tag)
+			if err != nil {
+				t.Fatalf("Error resolving tag; %v", err)
+			}
+			if actual != c.expected {
+				t.Errorf("Expected %v; got %v", c.expected, actual)
+			}
+		})
+	}
+}
 
 func Test_Download(t *testing.T) {
 	if os.Getenv("GITHUB_ACTIONS") != "" {
@@ -35,7 +69,7 @@ func Test_Download(t *testing.T) {
 		t.Fatalf("Error creating manager; %v", err)
 	}
 
-	if err := m.Download(context.Background()); err != nil {
+	if err := m.Download(context.Background(), "latest"); err != nil {
 		t.Fatalf("Error downloading assets; %v", err)
 	}
 }

--- a/app/pkg/config/config.go
+++ b/app/pkg/config/config.go
@@ -25,9 +25,6 @@ const (
 	LevelFlagName  = "level"
 	appName        = "foyle"
 	ConfigDir      = "." + appName
-
-	defaultVSCodeImage = "ghcr.io/jlewi/vscode-web-assets:latest"
-	defaultFoyleImage  = "ghcr.io/jlewi/foyle-vscode-ext:latest"
 )
 
 // Config represents the persistent configuration data for Foyle.
@@ -40,7 +37,7 @@ type Config struct {
 
 	Logging Logging       `json:"logging" yaml:"logging"`
 	Server  ServerConfig  `json:"server" yaml:"server"`
-	Assets  AssetConfig   `json:"assets" yaml:"assets"`
+	Assets  *AssetConfig  `json:"assets,omitempty" yaml:"assets,omitempty"`
 	Agent   *AgentConfig  `json:"agent,omitempty" yaml:"agent,omitempty"`
 	OpenAI  *OpenAIConfig `json:"openai,omitempty" yaml:"openai,omitempty"`
 	// AzureOpenAI contains configuration for Azure OpenAI. A non nil value means use Azure OpenAI.
@@ -124,8 +121,8 @@ type CorsConfig struct {
 
 // AssetConfig configures the assets
 type AssetConfig struct {
-	VSCode         Asset `json:"vsCode" yaml:"vsCode"`
-	FoyleExtension Asset `json:"foyleExtension" yaml:"foyleExtension"`
+	VSCode         *Asset `json:"vsCode,omitempty" yaml:"vsCode,omitempty"`
+	FoyleExtension *Asset `json:"foyleExtension,omitempty" yaml:"foyleExtension,omitempty"`
 }
 
 type Asset struct {
@@ -185,7 +182,6 @@ func InitViper(cmd *cobra.Command) error {
 
 	setAgentDefaults()
 	setServerDefaults()
-	setAssetDefaults()
 
 	// We need to attach to the command line flag if it was specified.
 	keyToflagName := map[string]string{
@@ -284,11 +280,6 @@ func setServerDefaults() {
 	// If we start using really slow models we may need to bump these to avoid timeouts.
 	viper.SetDefault("server.httpMaxWriteTimeout", 1*time.Minute)
 	viper.SetDefault("server.httpMaxReadTimeout", 1*time.Minute)
-}
-
-func setAssetDefaults() {
-	viper.SetDefault("assets.vsCode.uri", defaultVSCodeImage)
-	viper.SetDefault("assets.foyleExtension.uri", defaultFoyleImage)
 }
 
 func setAgentDefaults() {


### PR DESCRIPTION
* Rather than downloading assets based on the latest tag we should pick the image whose commit matches the commit of the binary

* This ensures the frontend and backend are built off the same version

* If the commit isn't specified in the build (E.g. a development version) then we default to the latest tag

Related to #45