### PR TITLE
Attach version information to downloaded assets 

### DIFF
--- a/frontend/foyle/Dockerfile
+++ b/frontend/foyle/Dockerfile
@@ -22,4 +22,6 @@ FROM scratch
 
 COPY --from=build /foyle/package.json /foyle/package.json
 COPY --from=build /foyle/package.nls.json /foyle/package.nls.json
+# version.json gets builts in build.sh
+COPY --from=build /foyle/version.json /foyle/version.json
 COPY --from=build /foyle/dist /foyle/dist

--- a/frontend/foyle/Dockerfile
+++ b/frontend/foyle/Dockerfile
@@ -3,6 +3,11 @@
 # The main difference is that we don't install vscode in the container; i.e. we don't call the install-vscode.sh script.
 FROM mcr.microsoft.com/devcontainers/typescript-node:18-bookworm as build
 
+# Build Args need to be after the FROM stage otherwise they don't get passed through to the RUN statment
+ARG VERSION=unknown
+ARG DATE=unknown
+ARG COMMIT=unknown
+
 # Not sure why this is needed since its not in the dev container.
 RUN apt-get update -y && \
   apt-get install -y libxkbfile-dev

--- a/frontend/foyle/build.sh
+++ b/frontend/foyle/build.sh
@@ -4,3 +4,12 @@
 set -ex
 yarn
 yarn package-web
+
+cat > dist/version.json <<EOF
+{
+  "version": "$VERSION",
+  "date": "$DATE",
+  "commit": "$COMMIT"
+}
+EOF
+

--- a/frontend/foyle/build.sh
+++ b/frontend/foyle/build.sh
@@ -5,7 +5,7 @@ set -ex
 yarn
 yarn package-web
 
-cat > dist/version.json <<EOF
+cat > version.json <<EOF
 {
   "version": "$VERSION",
   "date": "$DATE",

--- a/frontend/vscode/web-assets/Dockerfile
+++ b/frontend/vscode/web-assets/Dockerfile
@@ -1,6 +1,11 @@
 # Should we pin this
 FROM us-west1-docker.pkg.dev/foyle-public/images/vscode as build
 
+# Build Args need to be after the FROM stage otherwise they don't get passed through to the RUN statment
+ARG VERSION=unknown
+ARG DATE=unknown
+ARG COMMIT=unknown
+
 COPY /frontend/vscode/web-assets /workspace
 RUN /workspace/build.sh
 

--- a/frontend/vscode/web-assets/build.sh
+++ b/frontend/vscode/web-assets/build.sh
@@ -13,3 +13,11 @@ echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.bashrc
 
 cd ${DIR}
 /usr/local/go/bin/go run . --vscode=/vscode --out=/assets
+
+cat > /assets/version.json <<EOF
+{
+  "version": "$VERSION",
+  "date": "$DATE",
+  "commit": "$COMMIT"
+}
+EOF


### PR DESCRIPTION
* Add build arguments for version, date, and commit information to Docerfile and update build script to include generating a version.json file with this information.

* Related to #45 
* We need to add information to the frontend assets so we know what version it is.
* We do this by adding a JSON file during the build process