### PR TITLE
Setup logging for human feedback

### DIFF
--- a/app/pkg/config/config.go
+++ b/app/pkg/config/config.go
@@ -133,7 +133,8 @@ type Asset struct {
 }
 
 type Logging struct {
-	Level string `json:"level" yaml:"level"`
+	Level  string `json:"level,omitempty" yaml:"level,omitempty"`
+	LogDir string `json:"logDir,omitempty" yaml:"logDir,omitempty"`
 }
 
 type TelemetryConfig struct {
@@ -152,6 +153,15 @@ func (c *Config) GetModel() string {
 
 	return c.Agent.Model
 }
+
+func (c *Config) GetLogDir() string {
+	if c.Logging.LogDir != "" {
+		return c.Logging.LogDir
+	}
+
+	return filepath.Join(c.GetConfigDir(), "logs")
+}
+
 func (c *Config) GetLogLevel() string {
 	if c.Logging.Level == "" {
 		return "info"


### PR DESCRIPTION
* We need to produce machine readable JSON logs
* We do this by creating two separate logging cores
  * This way we can have a consoleEncoder that potentially still writes in human readable format

Related to #7 