### PR TITLE
Fix bug with execute not sending blockIDs to the server

### DIFF
--- a/frontend/foyle/package.json
+++ b/frontend/foyle/package.json
@@ -24,6 +24,10 @@
       {
         "command": "foyle.helloWorld",
         "title": "Foyle HelloWorld"
+      },
+      {
+        "command": "foyle.printCell",
+        "title": "Foyle Print Cell Metadata"
       }
     ],
     "keybindings": [

--- a/frontend/foyle/src/web/controller.ts
+++ b/frontend/foyle/src/web/controller.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { promisify } from 'util';
 import * as constants from './constants';
+import * as converters from './converters';
 import * as client from './client';
 import * as agentpb from "../gen/foyle/v1alpha1/agent_pb";
 import * as docpb from "../gen/foyle/v1alpha1/doc_pb";
@@ -75,10 +76,8 @@ async function callExecute(cell: vscode.NotebookCell, client: client.FoyleClient
 
   const request = new agentpb.ExecuteRequest();
 
-  request.block = new docpb.Block();  
-  request.block.kind = docpb.BlockKind.CODE;
-  request.block.contents = cell.document.getText();  
-
+  request.block = converters.cellDataToBlock(converters.cellToCellData(cell));
+  
   return client.Execute(request).then((response) => {
     let output: vscode.NotebookCellOutput[] = [];
 

--- a/frontend/foyle/src/web/controller.ts
+++ b/frontend/foyle/src/web/controller.ts
@@ -66,6 +66,11 @@ export class Controller {
 }
 
 async function callExecute(cell: vscode.NotebookCell, client: client.FoyleClient): Promise<vscode.NotebookCellOutput[]> {
+  if (cell.metadata.hasOwnProperty("id")) {
+    console.log(`callExecute called on block id = ${cell.metadata["id"]}`);
+  } else {
+    console.log(`callExecute called on block without id`);
+  }
   console.log(`callExecute called ${cell.document.getText()}`); 
 
   const request = new agentpb.ExecuteRequest();

--- a/frontend/foyle/src/web/debug.ts
+++ b/frontend/foyle/src/web/debug.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+import {FoyleClient, getTraceID} from './client';
+import * as converters from './converters';
+import * as docpb from "../gen/foyle/v1alpha1/doc_pb";
+import * as agentpb from "../gen/foyle/v1alpha1/agent_pb";
+// printCell is a debug tool that prints the contents of a cell to the console
+// Its purpose is to help us debug problems by printing the contents of a cell
+// In particular the cell metadata
+export async function printCell() {
+  const editor = vscode.window.activeNotebookEditor;
+
+  if (!editor) {    
+    return;
+  }
+
+  if (editor?.selection.isEmpty) {    
+    return;
+  }
+  
+  // We subtract 1 because end is non-inclusive
+  const lastSelectedCell = editor?.selection.end - 1;
+  var lastActiveCell = editor?.notebook.cellAt(lastSelectedCell);  
+  console.log(`Cell value: ${lastActiveCell.document.getText()}`);
+  console.log(`Cell language: ${lastActiveCell.document.languageId}`);
+  console.log(`Cell kind: ${lastActiveCell.kind}`);
+  
+  Object.keys(lastActiveCell.metadata).forEach(key => {
+    console.log(`Cell Metadata key: ${key} value: ${lastActiveCell.metadata[key]}`);
+  });
+}

--- a/frontend/foyle/src/web/extension.ts
+++ b/frontend/foyle/src/web/extension.ts
@@ -5,6 +5,7 @@ import { Controller } from './controller';
 import {FoyleClient} from './client';
 import { Serializer } from './serializer';
 import * as generate from './generate';
+import * as debug from './debug';
 // Create a client for the backend.
 const client = new FoyleClient;
 
@@ -52,6 +53,8 @@ export function activate(context: vscode.ExtensionContext) {
 	// Here's where we register the command that will generate a completion using the AI model
 	// You can set a keybinding for this command in the package.json file
   context.subscriptions.push(vscode.commands.registerCommand("foyle.generate", generate.generateCompletion));
+
+	context.subscriptions.push(vscode.commands.registerCommand("foyle.printCell", debug.printCell));
 	context.subscriptions.push(disposable);
 }
 


### PR DESCRIPTION
The bug was in how we were converting the current cell to a block before sending it to the server.
We weren't using the converters that we wrote. We were using some other code that wasn't setting the metadata and therefore copying the block id to the request.

* I also added a vscode function that will print the cell metadata. This is useful for debugging and troubleshooting.

related to #7 