### PR TITLE
Support markdown documents

### DIFF
--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: Getting started with Foyle?
+description: Getting started with Foyle
 weight: 2
 ---
 
@@ -97,3 +97,7 @@ If you are unhappy with the default key binding to generate a completion you can
 1. Click the gear icon in the lower left window and then select "Keyboard shortcuts"
 1. Search for "Foyle"
 1. Change the keybinding for `Foyle: generate a completion` to the keybinding you want to use
+
+## Where to go next
+
+* [Using Markdown Files](/docs/markdown/)

--- a/docs/content/en/docs/markdown/_index.md
+++ b/docs/content/en/docs/markdown/_index.md
@@ -1,0 +1,24 @@
+---
+title: Markdown Support
+description: Using Markdown Files In Foyle
+weight: 2
+---
+
+## Markdown Support
+
+Foyle supports markdown files. Using Foyle you can
+
+* Open existing markdown files in the VSCode Notebook Editor
+* Automatically render and execute code blocks as code cells in your notebook
+* Save your notebook as a markdown file
+
+To use markdown files in Foyle just give your file an extension of `.md` or `.markdown`. When you open the file in Foyle
+it will be automatically rendered as a notebook.
+
+**Important** When persisting notebooks as markdown cell outputs are currently not saved. This feature may be added
+in the future.
+
+## When to use Markdown Files
+
+Markdown files are useful when you are working in a shared code repository that is already using markdown files
+for documentation and playbooks.

--- a/frontend/foyle/package.json
+++ b/frontend/foyle/package.json
@@ -35,7 +35,7 @@
         "command": "foyle.generate",
         "key": "win+;",
         "mac": "cmd+;",
-        "when": "resourceExtname==.foyle"
+        "when": "resourceExtname==.foyle || resourceExtname==.md || resourceExtname==.markdown"
       }
     ],
     "configuration": {
@@ -60,6 +60,15 @@
         "selector": [
           {
             "filenamePattern": "*.{foyle}"
+          }
+        ]
+      },
+      {
+        "type": "foyle-notebook-md",
+        "displayName": "Foyle Notebook",
+        "selector": [
+          {
+            "filenamePattern": "*.{md,markdown}"
           }
         ]
       }  

--- a/frontend/foyle/package.json
+++ b/frontend/foyle/package.json
@@ -62,7 +62,17 @@
             "filenamePattern": "*.{foyle}"
           }
         ]
-      }
+      },
+      {
+				"type": "markdown-notebook",
+				"displayName": "Markdown Notebook",
+				"priority": "option",
+				"selector": [
+					{
+						"filenamePattern": "*.{md,markdown}"
+					}
+				]
+			}
     ],
     "languages": [
       {

--- a/frontend/foyle/package.json
+++ b/frontend/foyle/package.json
@@ -62,17 +62,7 @@
             "filenamePattern": "*.{foyle}"
           }
         ]
-      },
-      {
-				"type": "markdown-notebook",
-				"displayName": "Markdown Notebook",
-				"priority": "option",
-				"selector": [
-					{
-						"filenamePattern": "*.{md,markdown}"
-					}
-				]
-			}
+      }  
     ],
     "languages": [
       {

--- a/frontend/foyle/src/web/controller.ts
+++ b/frontend/foyle/src/web/controller.ts
@@ -8,10 +8,6 @@ import * as docpb from "../gen/foyle/v1alpha1/doc_pb";
 
 // Controller handles execution of cells.
 export class Controller {
-  // readonly label: string = "Foyle Notebook";  
-  // readonly notebookType: string = "foyle-notebook";
-  // readonly id: string = "foyle-notebook-kernel";
-
   // The controller needs to register the languages it handles. Each cell in the
   // notebook has a langId field. That is used to match it to the supported kernel.
   // I think that is used to match the controller to the cell.

--- a/frontend/foyle/src/web/controller.ts
+++ b/frontend/foyle/src/web/controller.ts
@@ -9,8 +9,8 @@ import * as docpb from "../gen/foyle/v1alpha1/doc_pb";
 // Controller handles execution of cells.
 export class Controller {
   readonly label: string = "Foyle Notebook";  
-  readonly notebookType: string = "foyle-notebook";
-  readonly id: string = "foyle-notebook-kernel";
+  readonly notebookType: string = "";
+  readonly id: string = "";
 
   // The controller needs to register the languages it handles. Each cell in the
   // notebook has a langId field. That is used to match it to the supported kernel.
@@ -20,12 +20,10 @@ export class Controller {
   private client: client.FoyleClient;
   private readonly _controller: vscode.NotebookController;
   private _executionOrder = 0;    
-  constructor(client: client.FoyleClient, isInteractive?: boolean) {
+  constructor(client: client.FoyleClient, notebookType: string) {
     this.client = client;
-    if (isInteractive) {
-      this.id = "foyle-notebook-interactive-kernel";
-      this.notebookType = "interactive";
-    }
+    this.id = `${notebookType}-kernel`;   
+    this.label = notebookType; 
     this._controller = vscode.notebooks.createNotebookController(
       this.id,
       this.notebookType,

--- a/frontend/foyle/src/web/controller.ts
+++ b/frontend/foyle/src/web/controller.ts
@@ -9,8 +9,8 @@ import * as docpb from "../gen/foyle/v1alpha1/doc_pb";
 // Controller handles execution of cells.
 export class Controller {
   readonly label: string = "Foyle Notebook";  
-  readonly notebookType: string = "";
-  readonly id: string = "";
+  readonly notebookType: string = "foyle-notebook";
+  readonly id: string = "foyle-notebook-kernel";
 
   // The controller needs to register the languages it handles. Each cell in the
   // notebook has a langId field. That is used to match it to the supported kernel.
@@ -20,10 +20,12 @@ export class Controller {
   private client: client.FoyleClient;
   private readonly _controller: vscode.NotebookController;
   private _executionOrder = 0;    
-  constructor(client: client.FoyleClient, notebookType: string) {
+  constructor(client: client.FoyleClient, isInteractive?: boolean) {
     this.client = client;
-    this.id = `${notebookType}-kernel`;   
-    this.label = notebookType; 
+    if (isInteractive) {
+      this.id = "foyle-notebook-interactive-kernel";
+      this.notebookType = "interactive";
+    }
     this._controller = vscode.notebooks.createNotebookController(
       this.id,
       this.notebookType,

--- a/frontend/foyle/src/web/controller.ts
+++ b/frontend/foyle/src/web/controller.ts
@@ -20,12 +20,8 @@ export class Controller {
   private client: client.FoyleClient;
   private readonly _controller: vscode.NotebookController;
   private _executionOrder = 0;    
-  constructor(client: client.FoyleClient, isInteractive?: boolean) {
-    this.client = client;
-    if (isInteractive) {
-      this.id = "foyle-notebook-interactive-kernel";
-      this.notebookType = "interactive";
-    }
+  constructor(client: client.FoyleClient) {
+    this.client = client;    
     this._controller = vscode.notebooks.createNotebookController(
       this.id,
       this.notebookType,

--- a/frontend/foyle/src/web/controller.ts
+++ b/frontend/foyle/src/web/controller.ts
@@ -8,9 +8,9 @@ import * as docpb from "../gen/foyle/v1alpha1/doc_pb";
 
 // Controller handles execution of cells.
 export class Controller {
-  readonly label: string = "Foyle Notebook";  
-  readonly notebookType: string = "foyle-notebook";
-  readonly id: string = "foyle-notebook-kernel";
+  // readonly label: string = "Foyle Notebook";  
+  // readonly notebookType: string = "foyle-notebook";
+  // readonly id: string = "foyle-notebook-kernel";
 
   // The controller needs to register the languages it handles. Each cell in the
   // notebook has a langId field. That is used to match it to the supported kernel.
@@ -20,12 +20,12 @@ export class Controller {
   private client: client.FoyleClient;
   private readonly _controller: vscode.NotebookController;
   private _executionOrder = 0;    
-  constructor(client: client.FoyleClient) {
+  constructor(client: client.FoyleClient, id: string, notebookType: string, label: string) {
     this.client = client;    
     this._controller = vscode.notebooks.createNotebookController(
-      this.id,
-      this.notebookType,
-      this.label
+      id,
+      notebookType,
+      label
     );
 
     this._controller.supportedLanguages = this.supportedLanguages;

--- a/frontend/foyle/src/web/extension.ts
+++ b/frontend/foyle/src/web/extension.ts
@@ -27,11 +27,6 @@ export function activate(context: vscode.ExtensionContext) {
 	// notebookType must match the value in package.json
 	context.subscriptions.push(new Controller(client, "foyle-notebook", "foyle-notebook", "Foyle Notebook"));
 	context.subscriptions.push(new Controller(client, "foyle-notebook-md", "foyle-notebook-md", "Foyle Notebook Markdown"));
-  //context.subscriptions.push(new Controller(client, "foyle-notebook"));
-  //context.subscriptions.push(new Controller(client, "foyle-md-notebook"));
-  
-  // TODO(jeremy): Register a command to handle generation
-  //context.subscriptions.push(vscode.commands.registerCommand("foyle.generate", handleGenerate));
 
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated

--- a/frontend/foyle/src/web/extension.ts
+++ b/frontend/foyle/src/web/extension.ts
@@ -22,10 +22,11 @@ export function activate(context: vscode.ExtensionContext) {
   );
   
 	// Register the markdown serializer
-	//context.subscriptions.push(vscode.workspace.registerNotebookSerializer("foyle-md-notebook", new MarkdownProvider(), providerOptions));
+	context.subscriptions.push(vscode.workspace.registerNotebookSerializer("foyle-notebook-md", new MarkdownProvider(), providerOptions));
 	// Register the controllers for the notebooks
 	// notebookType must match the value in package.json
 	context.subscriptions.push(new Controller(client, "foyle-notebook", "foyle-notebook", "Foyle Notebook"));
+	context.subscriptions.push(new Controller(client, "foyle-notebook-md", "foyle-notebook-md", "Foyle Notebook Markdown"));
   //context.subscriptions.push(new Controller(client, "foyle-notebook"));
   //context.subscriptions.push(new Controller(client, "foyle-md-notebook"));
   

--- a/frontend/foyle/src/web/extension.ts
+++ b/frontend/foyle/src/web/extension.ts
@@ -24,7 +24,8 @@ export function activate(context: vscode.ExtensionContext) {
 	// Register the markdown serializer
 	//context.subscriptions.push(vscode.workspace.registerNotebookSerializer("foyle-md-notebook", new MarkdownProvider(), providerOptions));
 	// Register the controller for the notebook
-  context.subscriptions.push(new Controller(client, "foyle-notebook"));
+	context.subscriptions.push(new Controller(client));
+  //context.subscriptions.push(new Controller(client, "foyle-notebook"));
   //context.subscriptions.push(new Controller(client, "foyle-md-notebook"));
   
   // TODO(jeremy): Register a command to handle generation

--- a/frontend/foyle/src/web/extension.ts
+++ b/frontend/foyle/src/web/extension.ts
@@ -22,21 +22,11 @@ export function activate(context: vscode.ExtensionContext) {
   );
   
 	// Register the markdown serializer
-	context.subscriptions.push(vscode.workspace.registerNotebookSerializer('markdown-notebook', new MarkdownProvider(), providerOptions));
+	//context.subscriptions.push(vscode.workspace.registerNotebookSerializer("foyle-md-notebook", new MarkdownProvider(), providerOptions));
 	// Register the controller for the notebook
-  context.subscriptions.push(new Controller(client));
-  context.subscriptions.push(new Controller(client, true));
+  context.subscriptions.push(new Controller(client, "foyle-notebook"));
+  //context.subscriptions.push(new Controller(client, "foyle-md-notebook"));
   
-
-  context.subscriptions.push(vscode.commands.registerCommand("foyle-notebook.newInteractive", async () => {
-		const result: { inputUri: vscode.Uri, notebookUri?: vscode.Uri, notebookEditor?: vscode.NotebookEditor } | undefined = await vscode.commands.executeCommand('interactive.open',
-			undefined,
-			undefined,
-			`${context.extension.id}/foyle-notebook-interactive-kernel`,
-			undefined
-		);
-	}));
-
   // TODO(jeremy): Register a command to handle generation
   //context.subscriptions.push(vscode.commands.registerCommand("foyle.generate", handleGenerate));
 

--- a/frontend/foyle/src/web/extension.ts
+++ b/frontend/foyle/src/web/extension.ts
@@ -23,8 +23,9 @@ export function activate(context: vscode.ExtensionContext) {
   
 	// Register the markdown serializer
 	//context.subscriptions.push(vscode.workspace.registerNotebookSerializer("foyle-md-notebook", new MarkdownProvider(), providerOptions));
-	// Register the controller for the notebook
-	context.subscriptions.push(new Controller(client));
+	// Register the controllers for the notebooks
+	// notebookType must match the value in package.json
+	context.subscriptions.push(new Controller(client, "foyle-notebook", "foyle-notebook", "Foyle Notebook"));
   //context.subscriptions.push(new Controller(client, "foyle-notebook"));
   //context.subscriptions.push(new Controller(client, "foyle-md-notebook"));
   

--- a/frontend/foyle/src/web/extension.ts
+++ b/frontend/foyle/src/web/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import { Controller } from './controller';
 import {FoyleClient} from './client';
 import { Serializer } from './serializer';
+import { MarkdownProvider , providerOptions} from './markdown';
 import * as generate from './generate';
 import * as debug from './debug';
 // Create a client for the backend.
@@ -20,6 +21,8 @@ export function activate(context: vscode.ExtensionContext) {
     )
   );
   
+	// Register the markdown serializer
+	context.subscriptions.push(vscode.workspace.registerNotebookSerializer('markdown-notebook', new MarkdownProvider(), providerOptions));
 	// Register the controller for the notebook
   context.subscriptions.push(new Controller(client));
   context.subscriptions.push(new Controller(client, true));

--- a/frontend/foyle/src/web/markdown.ts
+++ b/frontend/foyle/src/web/markdown.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// File originally based on
+// https://github.com/microsoft/vscode-markdown-notebook/blob/main/src/extension.ts
+import * as vscode from 'vscode';
+import { parseMarkdown, writeCellsToMarkdown, RawNotebookCell } from './markdownParser';
+
+export const providerOptions = {
+	transientMetadata: {
+		runnable: true,
+		editable: true,
+		custom: true,
+	},
+	transientOutputs: true
+};
+
+export function activate(context: vscode.ExtensionContext) {	
+}
+
+// there are globals in workers and nodejs
+declare class TextDecoder {
+	decode(data: Uint8Array): string;
+}
+declare class TextEncoder {
+	encode(data: string): Uint8Array;
+}
+
+export class MarkdownProvider implements vscode.NotebookSerializer {
+
+	private readonly decoder = new TextDecoder();
+	private readonly encoder = new TextEncoder();
+
+	deserializeNotebook(data: Uint8Array, _token: vscode.CancellationToken): vscode.NotebookData | Thenable<vscode.NotebookData> {
+		const content = this.decoder.decode(data);
+
+		const cellRawData = parseMarkdown(content);
+		const cells = cellRawData.map(rawToNotebookCellData);
+
+		return {
+			cells
+		};
+	}
+
+	serializeNotebook(data: vscode.NotebookData, _token: vscode.CancellationToken): Uint8Array | Thenable<Uint8Array> {
+		const stringOutput = writeCellsToMarkdown(data.cells);
+		return this.encoder.encode(stringOutput);
+	}
+}
+
+export function rawToNotebookCellData(data: RawNotebookCell): vscode.NotebookCellData {
+	return <vscode.NotebookCellData>{
+		kind: data.kind,
+		languageId: data.language,
+		metadata: { leadingWhitespace: data.leadingWhitespace, trailingWhitespace: data.trailingWhitespace, indentation: data.indentation },
+		outputs: [],
+		value: data.content
+	};
+}

--- a/frontend/foyle/src/web/markdownParser.ts
+++ b/frontend/foyle/src/web/markdownParser.ts
@@ -5,6 +5,7 @@
 // File originally based on
 // https://github.com/microsoft/vscode-markdown-notebook/blob/main/src/markdownParser.ts
 import * as vscode from 'vscode';
+import { bashLang } from './constants';
 
 export interface RawNotebookCell {
 	indentation?: string;
@@ -91,8 +92,14 @@ export function parseMarkdown(content: string): RawNotebookCell[] {
 	}
 
 	function parseCodeBlock(leadingWhitespace: string, codeBlockStart: ICodeBlockStart): void {
-		const language = LANG_IDS.get(codeBlockStart.langId) || codeBlockStart.langId;
-		const startSourceIdx = ++i;
+		var language = LANG_IDS.get(codeBlockStart.langId) || codeBlockStart.langId;
+		
+    // Default the language to the bash language that the executor knows how to execute
+    if (language === "") {
+      language = bashLang;
+    }
+
+    const startSourceIdx = ++i;
 		while (true) {
 			const currLine = lines[i];
 			if (i >= lines.length) {

--- a/frontend/foyle/src/web/markdownParser.ts
+++ b/frontend/foyle/src/web/markdownParser.ts
@@ -1,0 +1,200 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// File originally based on
+// https://github.com/microsoft/vscode-markdown-notebook/blob/main/src/markdownParser.ts
+import * as vscode from 'vscode';
+
+export interface RawNotebookCell {
+	indentation?: string;
+	leadingWhitespace: string;
+	trailingWhitespace: string;
+	language: string;
+	content: string;
+	kind: vscode.NotebookCellKind;
+}
+
+const LANG_IDS = new Map([
+	['bat', 'batch'],
+	['c++', 'cpp'],
+	['js', 'javascript'],
+	['ts', 'typescript'],
+	['cs', 'csharp'],
+	['py', 'python'],
+	['py2', 'python'],
+	['py3', 'python'],
+]);
+const LANG_ABBREVS = new Map(
+	Array.from(LANG_IDS.keys()).map(k => [LANG_IDS.get(k), k])
+);
+
+interface ICodeBlockStart {
+	langId: string;
+	indentation: string
+}
+
+/**
+ * Note - the indented code block parsing is basic. It should only be applied inside lists, indentation should be consistent across lines and
+ * between the start and end blocks, etc. This is good enough for typical use cases.
+ */
+function parseCodeBlockStart(line: string): ICodeBlockStart | null {
+	const match = line.match(/(    |\t)?```(\S*)/);
+	return match && {
+		indentation: match[1],
+		langId: match[2]
+	};
+}
+
+function isCodeBlockStart(line: string): boolean {
+	return !!parseCodeBlockStart(line);
+}
+
+function isCodeBlockEndLine(line: string): boolean {
+	return !!line.match(/^\s*```/);
+}
+
+export function parseMarkdown(content: string): RawNotebookCell[] {
+	const lines = content.split(/\r?\n/g);
+	let cells: RawNotebookCell[] = [];
+	let i = 0;
+
+	// Each parse function starts with line i, leaves i on the line after the last line parsed
+	for (; i < lines.length;) {
+		const leadingWhitespace = i === 0 ? parseWhitespaceLines(true) : '';
+		if (i >= lines.length) {
+			break;
+		}
+		const codeBlockMatch = parseCodeBlockStart(lines[i]);
+		if (codeBlockMatch) {
+			parseCodeBlock(leadingWhitespace, codeBlockMatch);
+		} else {
+			parseMarkdownParagraph(leadingWhitespace);
+		}
+	}
+
+	function parseWhitespaceLines(isFirst: boolean): string {
+		let start = i;
+		const nextNonWhitespaceLineOffset = lines.slice(start).findIndex(l => l !== '');
+		let end: number; // will be next line or overflow
+		let isLast = false;
+		if (nextNonWhitespaceLineOffset < 0) {
+			end = lines.length;
+			isLast = true;
+		} else {
+			end = start + nextNonWhitespaceLineOffset;
+		}
+
+		i = end;
+		const numWhitespaceLines = end - start + (isFirst || isLast ? 0 : 1);
+		return '\n'.repeat(numWhitespaceLines);
+	}
+
+	function parseCodeBlock(leadingWhitespace: string, codeBlockStart: ICodeBlockStart): void {
+		const language = LANG_IDS.get(codeBlockStart.langId) || codeBlockStart.langId;
+		const startSourceIdx = ++i;
+		while (true) {
+			const currLine = lines[i];
+			if (i >= lines.length) {
+				break;
+			} else if (isCodeBlockEndLine(currLine)) {
+				i++; // consume block end marker
+				break;
+			}
+
+			i++;
+		}
+
+		const content = lines.slice(startSourceIdx, i - 1)
+			.map(line => line.replace(new RegExp('^' + codeBlockStart.indentation), ''))
+			.join('\n');
+		const trailingWhitespace = parseWhitespaceLines(false);
+		cells.push({
+			language,
+			content,
+			kind: vscode.NotebookCellKind.Code,
+			leadingWhitespace: leadingWhitespace,
+			trailingWhitespace: trailingWhitespace,
+			indentation: codeBlockStart.indentation
+		});
+	}
+
+	function parseMarkdownParagraph(leadingWhitespace: string): void {
+		const startSourceIdx = i;
+		while (true) {
+			if (i >= lines.length) {
+				break;
+			}
+
+			const currLine = lines[i];
+			if (currLine === '' || isCodeBlockStart(currLine)) {
+				break;
+			}
+
+			i++;
+		}
+
+		const content = lines.slice(startSourceIdx, i).join('\n');
+		const trailingWhitespace = parseWhitespaceLines(false);
+		cells.push({
+			language: 'markdown',
+			content,
+			kind: vscode.NotebookCellKind.Markup,
+			leadingWhitespace: leadingWhitespace,
+			trailingWhitespace: trailingWhitespace
+		});
+	}
+
+	return cells;
+}
+
+export function writeCellsToMarkdown(cells: ReadonlyArray<vscode.NotebookCellData>): string {
+	let result = '';
+	for (let i = 0; i < cells.length; i++) {
+		const cell = cells[i];
+		if (i === 0) {
+			result += cell.metadata?.leadingWhitespace ?? '';
+		}
+
+		if (cell.kind === vscode.NotebookCellKind.Code) {
+			const indentation = cell.metadata?.indentation || '';
+			const languageAbbrev = LANG_ABBREVS.get(cell.languageId) ?? cell.languageId;
+			const codePrefix = indentation + '```' + languageAbbrev + '\n';
+			const contents = cell.value.split(/\r?\n/g)
+				.map(line => indentation + line)
+				.join('\n');
+			const codeSuffix = '\n' + indentation + '```';
+
+			result += codePrefix + contents + codeSuffix;
+		} else {
+			result += cell.value;
+		}
+
+		result += getBetweenCellsWhitespace(cells, i);
+	}
+	return result;
+}
+
+function getBetweenCellsWhitespace(cells: ReadonlyArray<vscode.NotebookCellData>, idx: number): string {
+	const thisCell = cells[idx];
+	const nextCell = cells[idx + 1];
+
+	if (!nextCell) {
+		return thisCell.metadata?.trailingWhitespace ?? '\n';
+	}
+
+	const trailing = thisCell.metadata?.trailingWhitespace;
+	const leading = nextCell.metadata?.leadingWhitespace;
+
+	if (typeof trailing === 'string' && typeof leading === 'string') {
+		return trailing + leading;
+	}
+
+	// One of the cells is new
+	const combined = (trailing ?? '') + (leading ?? '');
+	if (!combined || combined === '\n') {
+		return '\n\n';
+	}
+
+	return combined;
+}

--- a/frontend/foyle/src/web/test/suite/markdown.test.ts
+++ b/frontend/foyle/src/web/test/suite/markdown.test.ts
@@ -1,0 +1,213 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { parseMarkdown, writeCellsToMarkdown } from '../../markdownParser';
+import { rawToNotebookCellData } from '../../markdown';
+import { bashLang } from '../../constants';
+
+// Originally copied from 
+// https://github.com/microsoft/vscode-markdown-notebook/blob/main/src/test/suite/index.ts
+
+suite('parseMarkdown', () => {
+	test('markdown cell', () => {
+		const cells = parseMarkdown('# hello');
+		assert.strictEqual(cells.length, 1);
+		assert.strictEqual(cells[0].content, '# hello');
+		assert.strictEqual(cells[0].leadingWhitespace, '');
+		assert.strictEqual(cells[0].trailingWhitespace, '');
+	});
+
+	test('markdown cell, w/ whitespace', () => {
+		const cells = parseMarkdown('\n\n# hello\n');
+		assert.strictEqual(cells.length, 1);
+		assert.strictEqual(cells[0].content, '# hello');
+		assert.strictEqual(cells[0].leadingWhitespace, '\n\n');
+		assert.strictEqual(cells[0].trailingWhitespace, '\n');
+	});
+
+	test('2 markdown cells', () => {
+		const cells = parseMarkdown('# hello\n\n# goodbye\n');
+		assert.strictEqual(cells.length, 2);
+		assert.strictEqual(cells[0].content, '# hello');
+		assert.strictEqual(cells[0].leadingWhitespace, '');
+		assert.strictEqual(cells[0].trailingWhitespace, '\n\n');
+
+		assert.strictEqual(cells[1].content, '# goodbye');
+		assert.strictEqual(cells[1].leadingWhitespace, '');
+		assert.strictEqual(cells[1].trailingWhitespace, '\n');
+	});
+
+	test('code cell', () => {
+		const cells = parseMarkdown('```js\nlet x = 1;\n```');
+		assert.strictEqual(cells.length, 1);
+		assert.strictEqual(cells[0].content, 'let x = 1;');
+		assert.strictEqual(cells[0].leadingWhitespace, '');
+		assert.strictEqual(cells[0].trailingWhitespace, '');
+		assert.strictEqual(cells[0].language, 'javascript');
+	});
+
+  test('code cell no langid', () => {
+		const cells = parseMarkdown('```\necho hello world\n```');
+		assert.strictEqual(cells.length, 1);
+		assert.strictEqual(cells[0].content, 'echo hello world');
+		assert.strictEqual(cells[0].leadingWhitespace, '');
+		assert.strictEqual(cells[0].trailingWhitespace, '');
+		assert.strictEqual(cells[0].language, bashLang);
+	});
+
+	test('code cell, w/whitespace', () => {
+		const cells = parseMarkdown('\n\n```js\nlet x = 1;\n```\n\n');
+		assert.strictEqual(cells.length, 1);
+		assert.strictEqual(cells[0].content, 'let x = 1;');
+		assert.strictEqual(cells[0].leadingWhitespace, '\n\n');
+		assert.strictEqual(cells[0].trailingWhitespace, '\n\n');
+	});
+
+	test('code cell, markdown', () => {
+		const cells = parseMarkdown('```js\nlet x = 1;\n```\n\n# hello\nfoo\n');
+		assert.strictEqual(cells.length, 2);
+		assert.strictEqual(cells[0].content, 'let x = 1;');
+		assert.strictEqual(cells[0].leadingWhitespace, '');
+		assert.strictEqual(cells[0].trailingWhitespace, '\n\n');
+
+		assert.strictEqual(cells[1].content, '# hello\nfoo');
+		assert.strictEqual(cells[1].leadingWhitespace, '');
+		assert.strictEqual(cells[1].trailingWhitespace, '\n');
+	});
+
+	test('markdown, code cell', () => {
+		const cells = parseMarkdown('# hello\nfoo\n\n```js\nlet x = 1;\n```\n');
+		assert.strictEqual(cells.length, 2);
+
+		assert.strictEqual(cells[0].content, '# hello\nfoo');
+		assert.strictEqual(cells[0].leadingWhitespace, '');
+		assert.strictEqual(cells[0].trailingWhitespace, '\n\n');
+
+		assert.strictEqual(cells[1].content, 'let x = 1;');
+		assert.strictEqual(cells[1].leadingWhitespace, '');
+		assert.strictEqual(cells[1].trailingWhitespace, '\n');
+	});
+
+	test('markdown, code cell with no whitespace between', () => {
+		const cells = parseMarkdown('# hello\nfoo\n```js\nlet x = 1;\n```\n');
+		assert.strictEqual(cells.length, 2);
+
+		assert.strictEqual(cells[0].content, '# hello\nfoo');
+		assert.strictEqual(cells[0].leadingWhitespace, '');
+		assert.strictEqual(cells[0].trailingWhitespace, '\n');
+
+		assert.strictEqual(cells[1].content, 'let x = 1;');
+		assert.strictEqual(cells[1].leadingWhitespace, '');
+		assert.strictEqual(cells[1].trailingWhitespace, '\n');
+	});
+
+	test('indented code cell', () => {
+		const cells = parseMarkdown('    ```js\n    // indented js block\n    ```\n# More content');
+		assert.strictEqual(cells.length, 2);
+
+		assert.strictEqual(cells[0].content, '// indented js block');
+		assert.strictEqual(cells[0].indentation, '    ');
+
+		assert.strictEqual(cells[1].content, '# More content');
+	});
+
+	test('CRLF', () => {
+		const cells = parseMarkdown('```js\r\nlet x = 1;\r\n```\r\n\r\n# hello\r\nfoo\r\n');
+		assert.strictEqual(cells.length, 2);
+		assert.strictEqual(cells[0].content, 'let x = 1;');
+		assert.strictEqual(cells[0].leadingWhitespace, '');
+		assert.strictEqual(cells[0].trailingWhitespace, '\n\n');
+
+		assert.strictEqual(cells[1].content, '# hello\nfoo');
+		assert.strictEqual(cells[1].leadingWhitespace, '');
+		assert.strictEqual(cells[1].trailingWhitespace, '\n');
+	});
+
+	test('empty', () => {
+		const cells = parseMarkdown('');
+		assert.strictEqual(cells.length, 0);
+	});
+});
+
+suite('writeMarkdown', () => {
+	function testWriteMarkdown(markdownStr: string) {
+		const cells = parseMarkdown(markdownStr)
+			.map(rawToNotebookCellData);
+		assert.strictEqual(writeCellsToMarkdown(cells), markdownStr);
+	}
+
+	suite('writeMarkdown', () => {
+		test('idempotent', () => {
+			testWriteMarkdown('# hello');
+			testWriteMarkdown('\n\n# hello\n\n');
+			testWriteMarkdown('# hello\n\ngoodbye');
+
+			testWriteMarkdown('```js\nlet x = 1;\n```\n\n# hello\n');
+			testWriteMarkdown('```js\nlet x = 1;\n```\n\n```ts\nlet y = 2;\n```\n# hello\n');
+
+			testWriteMarkdown('    ```js\n    // indented code cell\n    ```');
+		});
+
+		test('append markdown cells', () => {
+			const cells = parseMarkdown(`# hello`)
+				.map(rawToNotebookCellData);
+			cells.push(<vscode.NotebookCellData>{
+				kind: vscode.NotebookCellKind.Markup,
+				languageId: 'markdown',
+				metadata: {},
+				outputs: [],
+				value: 'foo'
+			});
+			cells.push(<vscode.NotebookCellData>{
+				kind: vscode.NotebookCellKind.Markup,
+				languageId: 'markdown',
+				metadata: {},
+				outputs: [],
+				value: 'bar'
+			});
+
+			assert.strictEqual(writeCellsToMarkdown(cells), `# hello\n\nfoo\n\nbar\n`);
+		});
+
+		test('append code cells', () => {
+			const cells = parseMarkdown('```ts\nsome code\n```')
+				.map(rawToNotebookCellData);
+			cells.push(<vscode.NotebookCellData>{
+				kind: vscode.NotebookCellKind.Code,
+				languageId: 'typescript',
+				metadata: {},
+				outputs: [],
+				value: 'foo'
+			});
+			cells.push(<vscode.NotebookCellData>{
+				kind: vscode.NotebookCellKind.Code,
+				languageId: 'typescript',
+				metadata: {},
+				outputs: [],
+				value: 'bar'
+			});
+
+			assert.strictEqual(writeCellsToMarkdown(cells), '```ts\nsome code\n```\n\n```ts\nfoo\n```\n\n```ts\nbar\n```\n');
+		});
+
+		test('insert cells', () => {
+			const cells = parseMarkdown('# Hello\n\n## Header 2')
+				.map(rawToNotebookCellData);
+			cells.splice(1, 0, <vscode.NotebookCellData>{
+				kind: vscode.NotebookCellKind.Code,
+				languageId: 'typescript',
+				metadata: {},
+				outputs: [],
+				value: 'foo'
+			});
+			cells.splice(2, 0, <vscode.NotebookCellData>{
+				kind: vscode.NotebookCellKind.Code,
+				languageId: 'typescript',
+				metadata: {},
+				outputs: [],
+				value: 'bar'
+			});
+
+			assert.strictEqual(writeCellsToMarkdown(cells), '# Hello\n\n```ts\nfoo\n```\n\n```ts\nbar\n```\n\n## Header 2');
+		});
+	});
+});


### PR DESCRIPTION
* Use VSCode's markdown notebook extension as the basis for markdown support
* To support markdown we define a new new notebook type foyle-notebook-md and then register another copy of the controller for it
* The reason we need to register a new notebook-type is because serializers appear to be linked to the notebook-type. Within the serializer it didn't seem like we could easily get the original filename extension to determine what the encoding was.

Fix #19 