### PR TITLE
Prefactor: move BlockLog and LogEntry into api package

### DIFF
--- a/app/api/types.go
+++ b/app/api/types.go
@@ -1,4 +1,4 @@
-package analyze
+package api
 
 import (
 	"encoding/json"

--- a/app/api/types_test.go
+++ b/app/api/types_test.go
@@ -1,4 +1,4 @@
-package analyze
+package api
 
 import (
 	"encoding/json"

--- a/app/pkg/analyze/analyzer.go
+++ b/app/pkg/analyze/analyzer.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jlewi/foyle/app/api"
+
 	"github.com/jlewi/foyle/app/pkg/docs"
 	"github.com/jlewi/foyle/app/pkg/logs"
 	"github.com/jlewi/foyle/protos/go/foyle/v1alpha1"
@@ -71,10 +73,10 @@ func (a *Analyzer) Analyze(ctx context.Context, logsDir string, outDir string) (
 }
 
 // buildTraces creates a map of all the traces and initializes the blocks.
-func buildTraces(ctx context.Context, jsonFiles []string, resultFiles ResultFiles) (map[string]Trace, map[string]*BlockLog, error) {
+func buildTraces(ctx context.Context, jsonFiles []string, resultFiles ResultFiles) (map[string]api.Trace, map[string]*api.BlockLog, error) {
 	log := logs.FromContext(ctx)
 	// Entries is a mapping from a traceId to a list of logEntries associated with that entry.
-	traceEntries := make(map[string][]*LogEntry)
+	traceEntries := make(map[string][]*api.LogEntry)
 
 	for _, p := range jsonFiles {
 		log.Info("Reading file", "path", p)
@@ -86,7 +88,7 @@ func buildTraces(ctx context.Context, jsonFiles []string, resultFiles ResultFile
 		d := json.NewDecoder(f)
 
 		for {
-			entry := &LogEntry{}
+			entry := &api.LogEntry{}
 			err := d.Decode(entry)
 
 			if err != nil {
@@ -104,7 +106,7 @@ func buildTraces(ctx context.Context, jsonFiles []string, resultFiles ResultFile
 
 			items, ok := traceEntries[entry.TraceID()]
 			if !ok {
-				items = make([]*LogEntry, 0, 10)
+				items = make([]*api.LogEntry, 0, 10)
 			}
 			items = append(items, entry)
 			traceEntries[entry.TraceID()] = items
@@ -112,10 +114,10 @@ func buildTraces(ctx context.Context, jsonFiles []string, resultFiles ResultFile
 	}
 
 	// Store a map of all traces
-	traces := make(map[string]Trace)
+	traces := make(map[string]api.Trace)
 
 	// Build a map of the blocks
-	blocks := make(map[string]*BlockLog)
+	blocks := make(map[string]*api.BlockLog)
 
 	// Create encoders to write the traces
 	genFile, err := os.Create(resultFiles.GenerateTraces[0])
@@ -147,7 +149,7 @@ func buildTraces(ctx context.Context, jsonFiles []string, resultFiles ResultFile
 
 		// Update the blocks associated with this trace
 		switch t := trace.(type) {
-		case *GenerateTrace:
+		case *api.GenerateTrace:
 			for _, oBlock := range t.Response.GetBlocks() {
 				bid := oBlock.GetId()
 				if bid == "" {
@@ -155,7 +157,7 @@ func buildTraces(ctx context.Context, jsonFiles []string, resultFiles ResultFile
 				}
 				block, ok := blocks[bid]
 				if !ok {
-					block = &BlockLog{
+					block = &api.BlockLog{
 						ID: bid,
 					}
 					blocks[bid] = block
@@ -163,14 +165,14 @@ func buildTraces(ctx context.Context, jsonFiles []string, resultFiles ResultFile
 				block.GenTraceID = tid
 			}
 			enc = genEnc
-		case *ExecuteTrace:
+		case *api.ExecuteTrace:
 			bid := t.Request.GetBlock().GetId()
 			if bid == "" {
 				continue
 			}
 			block, ok := blocks[bid]
 			if !ok {
-				block = &BlockLog{
+				block = &api.BlockLog{
 					ID: bid,
 				}
 				blocks[bid] = block
@@ -243,7 +245,7 @@ func initResultFiles(outDir string) ResultFiles {
 	}
 }
 
-func buildBlockLogs(ctx context.Context, traces map[string]Trace, blocks map[string]*BlockLog, outFile string) error {
+func buildBlockLogs(ctx context.Context, traces map[string]api.Trace, blocks map[string]*api.BlockLog, outFile string) error {
 	log := logs.FromContext(ctx)
 
 	oDir := filepath.Dir(outFile)
@@ -277,7 +279,7 @@ func buildBlockLogs(ctx context.Context, traces map[string]Trace, blocks map[str
 	return nil
 }
 
-func buildBlockLog(ctx context.Context, block *BlockLog, traces map[string]Trace) error {
+func buildBlockLog(ctx context.Context, block *api.BlockLog, traces map[string]api.Trace) error {
 	log := logs.FromContext(ctx)
 	log = log.WithValues("blockId", block.ID)
 	log.Info("Building block log", "block", block)
@@ -287,7 +289,7 @@ func buildBlockLog(ctx context.Context, block *BlockLog, traces map[string]Trace
 	}
 
 	if block.GenTraceID != "" {
-		genTrace, ok := traces[block.GenTraceID].(*GenerateTrace)
+		genTrace, ok := traces[block.GenTraceID].(*api.GenerateTrace)
 		if !ok {
 			log.Error(errors.New("Missing GenerateTrace for traceId"), "Error getting generate trace", "genTraceId", block.GenTraceID)
 		} else {
@@ -306,10 +308,10 @@ func buildBlockLog(ctx context.Context, block *BlockLog, traces map[string]Trace
 		}
 	}
 
-	var lastTrace *ExecuteTrace
+	var lastTrace *api.ExecuteTrace
 	// Get the last execution trace
 	for _, tid := range block.ExecTraceIDs {
-		trace, ok := traces[tid].(*ExecuteTrace)
+		trace, ok := traces[tid].(*api.ExecuteTrace)
 		if !ok {
 			log.Error(errors.New("Missing ExecuteTrace for traceId"), "Error getting execute trace", "execTraceId", tid)
 			continue
@@ -339,7 +341,7 @@ func buildBlockLog(ctx context.Context, block *BlockLog, traces map[string]Trace
 	return nil
 }
 
-func combineEntriesForTrace(ctx context.Context, entries []*LogEntry) (Trace, error) {
+func combineEntriesForTrace(ctx context.Context, entries []*api.LogEntry) (api.Trace, error) {
 	// First sort the entries by timestamp.
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].Time().Before(entries[j].Time())
@@ -360,8 +362,8 @@ func combineEntriesForTrace(ctx context.Context, entries []*LogEntry) (Trace, er
 	return nil, errors.New("Failed to identify trace type")
 }
 
-func combineGenerateTrace(ctx context.Context, entries []*LogEntry) (*GenerateTrace, error) {
-	trace := &GenerateTrace{}
+func combineGenerateTrace(ctx context.Context, entries []*api.LogEntry) (*api.GenerateTrace, error) {
+	trace := &api.GenerateTrace{}
 	for _, e := range entries {
 		if trace.TraceID == "" {
 			trace.TraceID = e.TraceID()
@@ -394,8 +396,8 @@ func combineGenerateTrace(ctx context.Context, entries []*LogEntry) (*GenerateTr
 	return trace, nil
 }
 
-func combineExecuteTrace(ctx context.Context, entries []*LogEntry) (*ExecuteTrace, error) {
-	trace := &ExecuteTrace{}
+func combineExecuteTrace(ctx context.Context, entries []*api.LogEntry) (*api.ExecuteTrace, error) {
+	trace := &api.ExecuteTrace{}
 	for _, e := range entries {
 		if trace.TraceID == "" {
 			trace.TraceID = e.TraceID()

--- a/app/pkg/analyze/analyzer_test.go
+++ b/app/pkg/analyze/analyzer_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jlewi/foyle/app/api"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/jlewi/foyle/app/pkg/testutil"
@@ -33,15 +35,15 @@ func shuffle(in []string) []string {
 func Test_BuildBlockLog(t *testing.T) {
 	type testCase struct {
 		name     string
-		block    *BlockLog
-		traces   map[string]Trace
-		expected *BlockLog
+		block    *api.BlockLog
+		traces   map[string]api.Trace
+		expected *api.BlockLog
 	}
 
-	traces := make(map[string]Trace)
+	traces := make(map[string]api.Trace)
 
 	const bid1 = "g123output1"
-	genTrace := &GenerateTrace{
+	genTrace := &api.GenerateTrace{
 		TraceID:   "g123",
 		StartTime: timeMustParse(time.RFC3339, "2021-01-01T00:00:00Z"),
 		EndTime:   timeMustParse(time.RFC3339, "2021-01-01T00:01:00Z"),
@@ -64,7 +66,7 @@ func Test_BuildBlockLog(t *testing.T) {
 		},
 	}
 
-	execTrace1 := &ExecuteTrace{
+	execTrace1 := &api.ExecuteTrace{
 		TraceID:   "e456",
 		StartTime: timeMustParse(time.RFC3339, "2021-01-02T00:00:00Z"),
 		EndTime:   timeMustParse(time.RFC3339, "2021-01-02T00:01:00Z"),
@@ -87,7 +89,7 @@ func Test_BuildBlockLog(t *testing.T) {
 		},
 	}
 
-	execTrace2 := &ExecuteTrace{
+	execTrace2 := &api.ExecuteTrace{
 		TraceID:   "e789",
 		StartTime: timeMustParse(time.RFC3339, "2021-01-03T00:00:00Z"),
 		EndTime:   timeMustParse(time.RFC3339, "2021-01-03T00:01:00Z"),
@@ -119,13 +121,13 @@ func Test_BuildBlockLog(t *testing.T) {
 	cases := []testCase{
 		{
 			name: "basic",
-			block: &BlockLog{
+			block: &api.BlockLog{
 				ID:         bid1,
 				GenTraceID: genTrace.TraceID,
 
 				ExecTraceIDs: execTraceIds,
 			},
-			expected: &BlockLog{
+			expected: &api.BlockLog{
 				ID:             bid1,
 				GenTraceID:     genTrace.TraceID,
 				ExecTraceIDs:   execTraceIds,
@@ -189,9 +191,9 @@ func Test_Analyzer(t *testing.T) {
 	}
 	d := json.NewDecoder(f)
 
-	actual := map[string]*BlockLog{}
+	actual := map[string]*api.BlockLog{}
 	for {
-		var b BlockLog
+		var b api.BlockLog
 		if err := d.Decode(&b); err != nil {
 			if err == io.EOF {
 				break
@@ -249,10 +251,10 @@ func checkGenTracesFiles(t *testing.T, path string) {
 		t.Errorf("Failed to open output file: %v", err)
 		return
 	}
-	traces := make([]*GenerateTrace, 0, 10)
+	traces := make([]*api.GenerateTrace, 0, 10)
 	d := json.NewDecoder(genFile)
 	for {
-		trace := &GenerateTrace{}
+		trace := &api.GenerateTrace{}
 		if err := d.Decode(trace); err != nil {
 			if err == io.EOF {
 				break
@@ -274,10 +276,10 @@ func checkExecuteTracesFiles(t *testing.T, path string) {
 		t.Errorf("Failed to open output file: %v", err)
 		return
 	}
-	traces := make([]*ExecuteTrace, 0, 10)
+	traces := make([]*api.ExecuteTrace, 0, 10)
 	d := json.NewDecoder(genFile)
 	for {
-		trace := &ExecuteTrace{}
+		trace := &api.ExecuteTrace{}
 		if err := d.Decode(trace); err != nil {
 			if err == io.EOF {
 				break
@@ -311,14 +313,14 @@ func Test_CombineGenerateEntries(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			entries := make([]*LogEntry, 0, 10)
+			entries := make([]*api.LogEntry, 0, 10)
 			testFile, err := os.Open(filepath.Join(cwd, "test_data", c.linesFile))
 			if err != nil {
 				t.Fatalf("Failed to open test file: %v", err)
 			}
 			d := json.NewDecoder(testFile)
 			for {
-				e := &LogEntry{}
+				e := &api.LogEntry{}
 				err := d.Decode(e)
 				if err != nil {
 					if err == io.EOF {
@@ -366,14 +368,14 @@ func Test_CombineExecuteEntries(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			entries := make([]*LogEntry, 0, 10)
+			entries := make([]*api.LogEntry, 0, 10)
 			testFile, err := os.Open(filepath.Join(cwd, "test_data", c.linesFile))
 			if err != nil {
 				t.Fatalf("Failed to open test file: %v", err)
 			}
 			d := json.NewDecoder(testFile)
 			for {
-				e := &LogEntry{}
+				e := &api.LogEntry{}
 				err := d.Decode(e)
 				if err != nil {
 					if err == io.EOF {


### PR DESCRIPTION
* Prefactoring in preparation for #69
* We want our forth coming PWA to be able to depend on the types but we don't want to pull in other parts of the analyze package.