### PR TITLE
Fix bug in Application.ApplyPaths

### DIFF
--- a/app/pkg/application/app.go
+++ b/app/pkg/application/app.go
@@ -306,6 +306,7 @@ func (a *App) SetupServer() (*server.Server, error) {
 func (a *App) ApplyPaths(ctx context.Context, paths []string) error {
 	log := util.LogFromContext(ctx)
 
+	yamlFiles := make([]string, 0, len(paths))
 	for _, resourcePath := range paths {
 		newPaths, err := util.FindYamlFiles(resourcePath)
 		if err != nil {
@@ -313,10 +314,10 @@ func (a *App) ApplyPaths(ctx context.Context, paths []string) error {
 			return err
 		}
 
-		paths = append(paths, newPaths...)
+		yamlFiles = append(yamlFiles, newPaths...)
 	}
 
-	for _, path := range paths {
+	for _, path := range yamlFiles {
 		err := a.apply(ctx, path)
 		if err != nil {
 			log.Error(err, "Apply failed", "path", path)

--- a/app/pkg/application/app.go
+++ b/app/pkg/application/app.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -316,7 +317,7 @@ func (a *App) ApplyPaths(ctx context.Context, paths []string) error {
 
 		yamlFiles = append(yamlFiles, newPaths...)
 	}
-
+	sort.Strings(yamlFiles)
 	for _, path := range yamlFiles {
 		err := a.apply(ctx, path)
 		if err != nil {

--- a/data/eval/gcp/gcb_hydros.foyle
+++ b/data/eval/gcp/gcb_hydros.foyle
@@ -1,0 +1,32 @@
+{
+  "blocks": [
+    {
+      "kind": "MARKUP",
+      "language": "markdown",
+      "contents": "Get the cloud build jobs for commit abc1234"
+    },
+    {
+      "kind": "CODE",
+      "language": "bash",
+      "contents": "gcloud builds list --limit=10 --format=\"value(ID,createTime,duration,tags,logUrl,status)\" --project=foyle-public --filter=\"tags:commit-abc1234\"",
+      "outputs": [
+        {
+          "items": [
+            {
+              "mime": "text/plain",
+              "textData": "exitCode: 0"
+            }
+          ]
+        },
+        {
+          "items": [
+            {
+              "mime": "text/plain",
+              "textData": "stdout:\n54e441b3-1bb4-46d4-8d5a-72f115b2c4cb\t2024-05-03T18:10:24+00:00\t\tus-west1-docker.pkg.dev_foyle-public_images_hydros_hydros;commit-e4d040b;version-v20240503T111024\thttps://console.cloud.google.com/cloud-build/builds/54e441b3-1bb4-46d4-8d5a-72f115b2c4cb?project=593472949942\tSUCCESS"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/eval/gcp/gcb_hydros_by_image.foyle
+++ b/data/eval/gcp/gcb_hydros_by_image.foyle
@@ -1,0 +1,24 @@
+{
+  "blocks": [
+    {
+      "kind": "MARKUP",
+      "language": "markdown",
+      "contents": "List the GCB jobs that build image backend/caribou"
+    },
+    {
+      "kind": "CODE",
+      "language": "bash",
+      "contents": "gcloud builds list --limit=10 --filter='tags=\"us-west1-docker.pkg.dev_foyle-public_images_backend_caribou\"' --format=\"value(ID,createTime,duration,tags,logUrl,status)\" --project=foyle-public",
+      "outputs": [
+        {
+          "items": [
+            {
+              "mime": "text/plain",
+              "textData": "exitCode: 0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/experiments/norag.yaml
+++ b/experiments/norag.yaml
@@ -1,0 +1,16 @@
+# Ground truth data
+kind: Experiment
+apiVersion: foyle.io/v1alpha1
+metadata:
+  name: "no-learning"
+spec:
+  evalDir: /Users/jlewi/git_foyle/data/eval
+  dbDir: /Users/jlewi/foyle_experiments/nolearning
+  sheetID: "1O0thD-p9DBF4G_shGMniivBB3pdaYifgSzWXBxELKqE"
+  sheetName: "Baseline-no-learning-Results"
+  agent:
+    model: gpt-3.5-turbo-0125
+    rag:
+      enabled: false
+      maxResults: 0
+


### PR DESCRIPTION
* We were processing each file multiple times because we weren't properly populating a new array with the results
  of FindYamlFiles