### PR TITLE
Include the vscode-web-assets image in each release

### DIFF
--- a/frontend/vscode/web-assets/image.yaml
+++ b/frontend/vscode/web-assets/image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vscode
   namespace: foyle
   labels:
-    env: dev
+    env: release
 spec:
   image: us-west1-docker.pkg.dev/foyle-public/images/vscode-web-assets
   source:


### PR DESCRIPTION
We need to include the vscode web assets image in each release. Otherwise foyle will be unable to download the assets because an image with the tag is missing.

Related to #99 