### PR TITLE
Assets download shouldn't use CWD if there is no config file

### DIFF
--- a/app/pkg/config/config.go
+++ b/app/pkg/config/config.go
@@ -194,7 +194,13 @@ func (c *Config) GetLogLevel() string {
 
 // GetConfigDir returns the configuration directory
 func (c *Config) GetConfigDir() string {
-	return filepath.Dir(viper.ConfigFileUsed())
+	configFile := viper.ConfigFileUsed()
+	if configFile != "" {
+		return filepath.Dir(configFile)
+	}
+
+	// Since there is no config file we will use the default config directory.
+	return binHome()
 }
 
 // IsValid validates the configuration and returns any errors.


### PR DESCRIPTION
* When a user runs assets download they may not have created a .foyle/config.yaml file yet

* As a result the ConfigDir will be the empty string and assets will be put into the local directory
* To solve this if the ConfigFile is empty we return the default config directory.

Fix #103 