### PR TITLE
Use ULIDs for block ids

### DIFF
--- a/app/api/types.go
+++ b/app/api/types.go
@@ -135,13 +135,12 @@ type Trace interface {
 // GenerateTrace is the trace of a generation request.
 type GenerateTrace struct {
 	// ID is the id of this trace
-	TraceID    string                     `json:"traceId"`
-	StartTime  time.Time                  `json:"startTime"`
-	EndTime    time.Time                  `json:"endTime"`
-	Request    *v1alpha1.GenerateRequest  `json:"request"`
-	Response   *v1alpha1.GenerateResponse `json:"response"`
-	EvalMode   bool                       `json:"evalMode"`
-	IDMappings []IDMapping                `json:"idMappings"`
+	TraceID   string                     `json:"traceId"`
+	StartTime time.Time                  `json:"startTime"`
+	EndTime   time.Time                  `json:"endTime"`
+	Request   *v1alpha1.GenerateRequest  `json:"request"`
+	Response  *v1alpha1.GenerateResponse `json:"response"`
+	EvalMode  bool                       `json:"evalMode"`
 }
 
 func (g *GenerateTrace) ID() string {
@@ -150,12 +149,6 @@ func (g *GenerateTrace) ID() string {
 
 func (g *GenerateTrace) Type() TraceType {
 	return GenerateTraceType
-}
-
-type IDMapping struct {
-	// BlockID is the id of the block this will be a UUID.
-	BlockID string `json:"blockId"`
-	// RunmeID is the id of the doc
 }
 
 // ExecuteTrace is the trace of an execution request.

--- a/app/api/types.go
+++ b/app/api/types.go
@@ -135,12 +135,13 @@ type Trace interface {
 // GenerateTrace is the trace of a generation request.
 type GenerateTrace struct {
 	// ID is the id of this trace
-	TraceID   string                     `json:"traceId"`
-	StartTime time.Time                  `json:"startTime"`
-	EndTime   time.Time                  `json:"endTime"`
-	Request   *v1alpha1.GenerateRequest  `json:"request"`
-	Response  *v1alpha1.GenerateResponse `json:"response"`
-	EvalMode  bool                       `json:"evalMode"`
+	TraceID    string                     `json:"traceId"`
+	StartTime  time.Time                  `json:"startTime"`
+	EndTime    time.Time                  `json:"endTime"`
+	Request    *v1alpha1.GenerateRequest  `json:"request"`
+	Response   *v1alpha1.GenerateResponse `json:"response"`
+	EvalMode   bool                       `json:"evalMode"`
+	IDMappings []IDMapping                `json:"idMappings"`
 }
 
 func (g *GenerateTrace) ID() string {
@@ -149,6 +150,12 @@ func (g *GenerateTrace) ID() string {
 
 func (g *GenerateTrace) Type() TraceType {
 	return GenerateTraceType
+}
+
+type IDMapping struct {
+	// BlockID is the id of the block this will be a UUID.
+	BlockID string `json:"blockId"`
+	// RunmeID is the id of the doc
 }
 
 // ExecuteTrace is the trace of an execution request.

--- a/app/pkg/docs/ids.go
+++ b/app/pkg/docs/ids.go
@@ -1,7 +1,7 @@
 package docs
 
 import (
-	"github.com/google/uuid"
+	"github.com/jlewi/foyle/app/pkg/runme/ulid"
 	"github.com/jlewi/foyle/protos/go/foyle/v1alpha1"
 )
 
@@ -13,11 +13,8 @@ func SetBlockIds(blocks []*v1alpha1.Block) ([]string, error) {
 
 	for i := range blocks {
 		if blocks[i].Id == "" {
-			newUid, err := uuid.NewRandom()
-			if err != nil {
-				return nil, err
-			}
-			blocks[i].Id = newUid.String()
+			// We use ULIDs for block ids because that's what RunMe expects
+			blocks[i].Id = ulid.GenerateID()
 		}
 		blockIds = append(blockIds, blocks[i].Id)
 	}

--- a/app/pkg/runme/converters/blocks_to_cells.go
+++ b/app/pkg/runme/converters/blocks_to_cells.go
@@ -34,13 +34,18 @@ func BlockToCell(block *v1alpha1.Block) (*parserv1.Cell, error) {
 		}
 		cellOutputs = append(cellOutputs, cOutput)
 	}
+
 	cellKind := BlockKindToCellKind(block.Kind)
-	return &parserv1.Cell{
+	cell := &parserv1.Cell{
 		LanguageId: block.Language,
 		Value:      block.Contents,
 		Kind:       cellKind,
 		Outputs:    cellOutputs,
-	}, nil
+		Metadata: map[string]string{
+			IdField: block.Id,
+		},
+	}
+	return cell, nil
 }
 
 func BlockKindToCellKind(kind v1alpha1.BlockKind) parserv1.CellKind {

--- a/app/pkg/runme/converters/cells_to_blocks.go
+++ b/app/pkg/runme/converters/cells_to_blocks.go
@@ -45,7 +45,16 @@ func CellToBlock(cell *parserv1.Cell) (*v1alpha1.Block, error) {
 		blockOutputs = append(blockOutputs, bOutput)
 	}
 	blockKind := CellKindToBlockKind(cell.Kind)
+
+	id := ""
+	if cell.Metadata != nil {
+		if newId, ok := cell.Metadata[IdField]; ok {
+			id = newId
+		}
+	}
+
 	return &v1alpha1.Block{
+		Id:       id,
 		Language: cell.LanguageId,
 		Contents: cell.Value,
 		Kind:     blockKind,

--- a/app/pkg/runme/converters/cells_to_blocks_test.go
+++ b/app/pkg/runme/converters/cells_to_blocks_test.go
@@ -23,6 +23,9 @@ var (
 			Notebook: &parserv1.Notebook{
 				Cells: []*parserv1.Cell{
 					{
+						Metadata: map[string]string{
+							"id": "1234",
+						},
 						Kind:       parserv1.CellKind_CELL_KIND_CODE,
 						LanguageId: "python",
 						Value:      "print('Hello World')",
@@ -42,6 +45,7 @@ var (
 			Doc: &v1alpha1.Doc{
 				Blocks: []*v1alpha1.Block{
 					{
+						Id:       "1234",
 						Language: "python",
 						Contents: "print('Hello World')",
 						Kind:     v1alpha1.BlockKind_CODE,

--- a/app/pkg/runme/converters/const.go
+++ b/app/pkg/runme/converters/const.go
@@ -1,4 +1,4 @@
-package runme
+package converters
 
 const (
 	IdField = "id"

--- a/app/pkg/runme/proxy.go
+++ b/app/pkg/runme/proxy.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jlewi/foyle/app/pkg/agent"
 	"github.com/jlewi/foyle/app/pkg/logs"
-	"github.com/jlewi/foyle/app/pkg/runme/ulid"
 	"github.com/jlewi/foyle/protos/go/foyle/v1alpha1"
 	aiv1alpha1 "github.com/stateful/runme/v3/pkg/api/gen/proto/go/runme/ai/v1alpha1"
 	"go.opentelemetry.io/otel/trace"
@@ -64,18 +63,6 @@ func (p *Proxy) GenerateCells(ctx context.Context, req *aiv1alpha1.GenerateCells
 	}
 	resp := &aiv1alpha1.GenerateCellsResponse{
 		Cells: cells,
-	}
-
-	// TODO(jeremy): Set the cell ids.
-	for i, cell := range resp.Cells {
-		if cell.Metadata == nil {
-			cell.Metadata = make(map[string]string)
-		}
-		id := ulid.GenerateID()
-		cell.Metadata[IdField] = id
-
-		// We need a log message so we can link the ulid and the block id.
-		log.Info("Generate ulid", "id", id, "blockId", agentResp.Blocks[i].Id)
 	}
 	return resp, nil
 }

--- a/developer_guides/runme.md
+++ b/developer_guides/runme.md
@@ -57,3 +57,9 @@ Lets try installing and reinstalling it
 ```bash {"id":"01HY75KYKE3SFAM5EXMDAVJDTQ"}
 echo "hello world"
 ```
+
+## Debugging the Runme Extension in vscode
+
+* It seems like you may need to run `yarn build` for changes to get picked up; running `F5` doesn't always seem to work
+* Console logs will show up in the `debug console` in the development workspace; not the instance of vscode that gets launched to run
+  your extension


### PR DESCRIPTION
* RunMe uses ULIDs for cell ids. If we switch to using ULIDs we can be consistent with what RunMe does and avoid having two different types of ids for blocks. This will avoid a lot of headaches.

Related to #110