### PR TITLE
Support loading training examples from GCS

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/honeycombio/otel-config-go v1.15.0
 	github.com/jlewi/foyle/protos/go v0.0.0-00010101000000-000000000000
 	github.com/jlewi/hydros v0.0.7-0.20240503183011-8f99ead373fb
-	github.com/jlewi/monogo v0.0.0-20240123191147-401afe194d74
+	github.com/jlewi/monogo v0.0.0-20240621212541-14462684ce69
 	github.com/maxence-charriere/go-app/v9 v9.8.0
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pkg/errors v0.9.1

--- a/app/go.sum
+++ b/app/go.sum
@@ -350,6 +350,10 @@ github.com/jlewi/hydros v0.0.7-0.20240503183011-8f99ead373fb h1:2G2k606S3Qcg40cz
 github.com/jlewi/hydros v0.0.7-0.20240503183011-8f99ead373fb/go.mod h1:4fV+JUCnexPY2ZbKzdfV/RsyrfralN832MsUSq/7FqE=
 github.com/jlewi/monogo v0.0.0-20240123191147-401afe194d74 h1:pbOw/rOMs0AZ494bGnI6DieGKwqoJQEjHWaJZrvxsJo=
 github.com/jlewi/monogo v0.0.0-20240123191147-401afe194d74/go.mod h1:4QWrn/wb+L6rHHO3u5N250qJYWaZlHn1a8tFuWhZCP8=
+github.com/jlewi/monogo v0.0.0-20240621134004-bb6520225771 h1:V6Ek4ZqTMG8iYF6azwbHn3QVyihIZ8GlwU57+WlXkdE=
+github.com/jlewi/monogo v0.0.0-20240621134004-bb6520225771/go.mod h1:s3nTD+owHZ6b+F13JdSpXLtrAH35pOqdwdcZEZ/gwBc=
+github.com/jlewi/monogo v0.0.0-20240621212541-14462684ce69 h1:E13AbOWwrGoFiOcoK+EeSdlXede0nnIuzswgXOT/PYM=
+github.com/jlewi/monogo v0.0.0-20240621212541-14462684ce69/go.mod h1:s3nTD+owHZ6b+F13JdSpXLtrAH35pOqdwdcZEZ/gwBc=
 github.com/jlewi/runme/v3 v3.0.0-20240524042602-a01f865c4617 h1:lyXrThCive3plQ/HyiYvklcdQ6F84bZ7DX+dMU01iik=
 github.com/jlewi/runme/v3 v3.0.0-20240524042602-a01f865c4617/go.mod h1:RSMUWGN5b1i4eXEAKbuksB/z8thptDXVKyZ6lRXMcJc=
 github.com/jlewi/runme/v3 v3.0.0-20240524044247-2657f0b08e0f h1:NFOdz6g8E44q5RPLXbUQBK+Ox+3tRqk+NG+rTXWHgcY=

--- a/app/pkg/config/config.go
+++ b/app/pkg/config/config.go
@@ -62,6 +62,10 @@ type Config struct {
 type LearnerConfig struct {
 	// LogDirs is an additional list of directories to search for logs.
 	LogDirs []string `json:"logDirs" yaml:"logDirs"`
+
+	// ExampleDirs is the list of directories to read/write examples.
+	// Can be a local path or GCS URI.
+	ExampleDirs []string `json:"exampleDirs" yaml:"exampleDirs"`
 }
 
 type EvalConfig struct {
@@ -200,9 +204,22 @@ func (c *Config) GetTracesDBDir() string {
 	return filepath.Join(c.GetLogDir(), "traces")
 }
 
-func (c *Config) GetTrainingDir() string {
-	return filepath.Join(c.GetConfigDir(), "training")
+func (c *Config) GetTrainingDirs() []string {
+	if c.Learner == nil {
+		return []string{}
+	}
+
+	dirs := c.Learner.ExampleDirs
+	// If dirs isn't set default to a local training directory
+	if len(dirs) == 0 {
+		dirs = []string{filepath.Join(c.GetConfigDir(), "training")}
+	}
+	return dirs
 }
+
+//func (c *Config) GetTrainingModelDir() string {
+//	return filepath.Join(c.GetTrainingDir(), c.GetModel())
+//}
 
 func (c *Config) GetLogLevel() string {
 	if c.Logging.Level == "" {

--- a/docs/content/en/docs/learning/_index.md
+++ b/docs/content/en/docs/learning/_index.md
@@ -57,3 +57,30 @@ directory
 ```bash
 foyle config set learner.logDirs=${RUNME_LOGS_DIR}
 ```
+
+## Sharing Learned Examples
+
+In a team setting, you should build a shared AI that learns from the feedback of all team members and assists
+all members. To do this you can configure Foyle to write and read examples from a shared location like GCS.
+If you'd like S3 support please vote up [issue #153](https://github.com/jlewi/foyle/issues/153).
+
+To configure Foyle to use a shared location for learned examples 
+
+1. Create a GCS bucket to store the learned examples
+
+   ```bash
+    gsutil mb gs://my-foyle-examples
+   ```
+   
+1. Configure Foyle to use the GCS bucket
+
+   ```bash
+   foyle config set learner.exampleDirs=gs://${YOUR_BUCKET}
+   ```
+
+Optionally you can configure Foyle to use a local location as well if you want to be able to use the AI without
+an internet connection.
+
+```bash
+foyle config set learner.exampleDirs=gs://${YOUR_BUCKET},/local/training/examples
+```

--- a/tech_notes/tn007_shared_learning.md
+++ b/tech_notes/tn007_shared_learning.md
@@ -1,0 +1,96 @@
+# Continuous Learning
+
+* **Author**: Jeremy Lewi
+* **Last Updated**: 2024-06-19
+* **Status**: Being drafted
+
+## Objective
+
+* Design a solution for sharing learning between multiple users
+
+## TL;DR
+
+The examples used for in context learning are currently stored locally. This makes it awkward to share a trained
+AI between team members. Users would have to manually swap the examples in order to benefit from each others learnings.
+There are a couple key design decisions
+
+* Do we centralize traces and block log events or only the learned examples?
+* Do we support loading examples from a single location or multiple locations?
+
+To simplify management I think we should do the following
+
+* Only move the learned examples to a central location
+* Trace/block logs should still be stored locally for each user
+* Add support for loading/saving shared examples to multiple locations
+
+Traces and block log events are currently stored in Pebble. Pebble doesn't have a good story for using shared
+storage [cockroachdb/pebble#3177](https://github.com/cockroachdb/pebble/issues/3177#issuecomment-2137614459). 
+We also don't have an immediate need to move the traces and block logs to a central location.
+
+Treating shared storage location as a backup location means Foyle can still operate fine if the shared storage location
+is inaccessible.
+
+## Proposal
+
+Users should be able to specify 
+
+1. Multiple additional locations to load examples from
+1. A backup location to save learned examples to
+
+### LearnerConfig Changes
+
+We can update LearnerConfig to support these changes
+
+```
+type LearnerConfig struct {
+    // SharedExamples is a list of locations to load examples from
+    SharedExamples []string `json:"sharedExamples,omitempty"`
+
+    // BackupExamples is the location to save learned examples to
+    BackupExamples string `json:"backupExamples,omitempty"`
+}
+```
+
+### Loading SharedExamples
+
+To support different storage systems (e.g. S3, GCS, local file system) we can define an interface for working
+with shared examples. We currently have the [FileHelper](https://github.com/jlewi/hydros/blob/751cd2b5f0c7671f4e178c75292c55a9d827ecee/pkg/files/interface.go#L11)
+interface
+
+```go
+type FileHelper interface {
+    Exists(path string) (bool, error)
+    NewReader(path string) (io.Reader, error)
+    NewWriter(path string) (io.Writer, error)
+}
+```
+
+Our current implementation of inMemoryDB requires a [Glob function](https://github.com/jlewi/foyle/blob/a811734050c23802e45b8d7a0031670c464c3971/app/pkg/learn/in_memory.go#L196)
+to find all the examples that should be loaded. We should a new interface to include the Glob.
+
+```go
+type Globber interface {
+    Glob(pattern string) ([]string, error)
+}
+```
+
+For object storage we can implement Glob by listing all the objects matching a prefix and then applying the glob;
+similar to this [code for matching a regex](https://github.com/jlewi/monogo/blob/c6693c86e89898f3a65c6f18b6b91b6e031c6dbd/gcp/gcs/util.go#L172)
+
+## Alternatives
+
+### Centralize Traces and Block Logs
+
+Since Pebble doesn't have a good story for using shared
+storage [cockroachdb/pebble#3177](https://github.com/cockroachdb/pebble/issues/3177#issuecomment-2137614459) there's
+no simple solution for moving the traces and block logs to a central location. 
+
+The main thing we lose by not centralizing the traces and block is the ability to do bulk analysis of traces and
+block events across all users. Since we don't have an immediate use case for that there's no reason to support it.
+
+
+
+
+
+
+

--- a/tech_notes/tn007_shared_learning.md
+++ b/tech_notes/tn007_shared_learning.md
@@ -77,6 +77,12 @@ type Globber interface {
 For object storage we can implement Glob by listing all the objects matching a prefix and then applying the glob;
 similar to this [code for matching a regex](https://github.com/jlewi/monogo/blob/c6693c86e89898f3a65c6f18b6b91b6e031c6dbd/gcp/gcs/util.go#L172)
 
+### Triggering Loading of SharedExamples
+
+For an initial implementation we can load shared examples when Foyle starts and perhaps periodically poll for
+new examples. I don't think there's any need to implement push based notifications for new examples.
+
+
 ## Alternatives
 
 ### Centralize Traces and Block Logs
@@ -88,7 +94,9 @@ no simple solution for moving the traces and block logs to a central location.
 The main thing we lose by not centralizing the traces and block is the ability to do bulk analysis of traces and
 block events across all users. Since we don't have an immediate use case for that there's no reason to support it.
 
+# References
 
+[DuckDB S3 Support](https://duckdb.org/docs/extensions/httpfs/s3api.html#:~:text=DuckDB%20conforms%20to%20the%20S3,common%20among%20industry%20storage%20providers.)
 
 
 


### PR DESCRIPTION
Support loading training examples from GCS

* This makes it easy to create a shared AI among a team.
* Refer to tn007_shared_learning.md for the design
* A limitation of the current approach is that we only load examples from shared storage that weren't created by the user
  at startup.
  
Fix #145