### PR TITLE
Prefactor to support different LLM providers

### DIFF
--- a/app/pkg/agent/agent.go
+++ b/app/pkg/agent/agent.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strings"
 
+	"github.com/jlewi/foyle/app/pkg/llms"
+
 	"github.com/jlewi/foyle/app/pkg/learn"
 
 	"github.com/go-logr/logr"
@@ -18,7 +20,6 @@ import (
 	"github.com/jlewi/foyle/app/pkg/oai"
 	"github.com/jlewi/foyle/protos/go/foyle/v1alpha1"
 	"github.com/pkg/errors"
-	"github.com/sashabaranov/go-openai"
 )
 
 const (
@@ -37,20 +38,20 @@ const (
 // Agent is the agent.
 type Agent struct {
 	v1alpha1.UnimplementedGenerateServiceServer
-	client *openai.Client
-	config config.Config
-	db     *learn.InMemoryExampleDB
+	completer llms.Completer
+	config    config.Config
+	db        *learn.InMemoryExampleDB
 }
 
-func NewAgent(cfg config.Config, client *openai.Client, inMemoryExampleDB *learn.InMemoryExampleDB) (*Agent, error) {
+func NewAgent(cfg config.Config, completer llms.Completer, inMemoryExampleDB *learn.InMemoryExampleDB) (*Agent, error) {
 	if cfg.Agent == nil {
 		return nil, errors.New("Configuration is missing AgentConfig; configuration must define the agent field.")
 	}
 	log := zapr.NewLogger(zap.L())
 	log.Info("Creating agent", "config", cfg.Agent)
 
-	if client == nil {
-		return nil, errors.New("OpenAI client is required")
+	if completer == nil {
+		return nil, errors.New("Completer is required")
 	}
 	if cfg.Agent.RAG != nil && cfg.Agent.RAG.Enabled {
 		if inMemoryExampleDB == nil {
@@ -62,9 +63,9 @@ func NewAgent(cfg config.Config, client *openai.Client, inMemoryExampleDB *learn
 	}
 
 	return &Agent{
-		client: client,
-		config: cfg,
-		db:     inMemoryExampleDB,
+		completer: completer,
+		config:    cfg,
+		db:        inMemoryExampleDB,
 	}, nil
 }
 
@@ -137,23 +138,7 @@ func (a *Agent) completeWithRetries(ctx context.Context, req *v1alpha1.GenerateR
 			return nil, errors.Wrapf(err, "Failed to execute prompt template")
 		}
 
-		messages := []openai.ChatCompletionMessage{
-			{Role: openai.ChatMessageRoleSystem,
-				Content: systemPrompt,
-			},
-			{Role: openai.ChatMessageRoleUser,
-				Content: sb.String(),
-			},
-		}
-		request := openai.ChatCompletionRequest{
-			Model:       a.config.GetModel(),
-			Messages:    messages,
-			MaxTokens:   2000,
-			Temperature: temperature,
-		}
-
-		log.Info("OpenAI:CreateChatCompletion", "request", request)
-		resp, err := a.client.CreateChatCompletion(ctx, request)
+		blocks, err := a.completer.Complete(ctx, systemPrompt, sb.String())
 
 		if err != nil {
 			if oai.ErrorIs(err, oai.ContextLengthExceededCode) {
@@ -167,45 +152,9 @@ func (a *Agent) completeWithRetries(ctx context.Context, req *v1alpha1.GenerateR
 			return nil, errors.Wrapf(err, "CreateChatCompletion failed")
 		}
 
-		log.Info("OpenAI:CreateChatCompletion response", "resp", resp)
-
-		blocks, err := a.parseResponse(ctx, &resp)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Failed to parse response")
-		}
-
 		return blocks, nil
 	}
 	err := errors.Errorf("Failed to generate a chat completion after %d tries", maxTries)
 	log.Error(err, "Failed to generate a chat completion", "maxTries", maxTries)
 	return nil, err
-}
-
-func (a *Agent) parseResponse(ctx context.Context, resp *openai.ChatCompletionResponse) ([]*v1alpha1.Block, error) {
-	log := logs.FromContext(ctx)
-	allBlocks := make([]*v1alpha1.Block, 0, 10)
-	for _, choice := range resp.Choices {
-		if choice.Message.Content == "" {
-			continue
-		}
-
-		blocks, err := docs.MarkdownToBlocks(choice.Message.Content)
-		if err != nil {
-			log.Error(err, "Failed to parse markdown to blocks", "markdown", choice.Message.Content)
-			b := &v1alpha1.Block{
-				Kind:     v1alpha1.BlockKind_MARKUP,
-				Contents: choice.Message.Content,
-			}
-			allBlocks = append(allBlocks, b)
-			continue
-		}
-
-		// Set block ids
-		if _, err := docs.SetBlockIds(blocks); err != nil {
-			return nil, errors.Wrapf(err, "Failed to set block ids")
-		}
-
-		allBlocks = append(allBlocks, blocks...)
-	}
-	return allBlocks, nil
 }

--- a/app/pkg/eval/evaluator.go
+++ b/app/pkg/eval/evaluator.go
@@ -145,6 +145,12 @@ func (e *Evaluator) setupAgent(ctx context.Context, agentConfig api.AgentConfig)
 		return nil, err
 	}
 
+	// TODO(jeremy): This will need to be updated when we support other configurations.
+	completer, err := oai.NewCompleter(cfg, client)
+	if err != nil {
+		return nil, err
+	}
+
 	log := logs.FromContext(ctx)
 	log.Info("Creating agen without inMemoryExampleDB", "config", cfg.Agent)
 	if cfg.Agent.RAG != nil && cfg.Agent.RAG.Enabled {
@@ -152,7 +158,7 @@ func (e *Evaluator) setupAgent(ctx context.Context, agentConfig api.AgentConfig)
 	}
 
 	// TODO(jeremy): How should we construct inMemoryExampleDB? In the eval case?
-	agent, err := agent.NewAgent(cfg, client, nil)
+	agent, err := agent.NewAgent(cfg, completer, nil)
 
 	if err != nil {
 		return nil, err

--- a/app/pkg/learn/in_memory_test.go
+++ b/app/pkg/learn/in_memory_test.go
@@ -100,7 +100,8 @@ func Test_InMemoryDB(t *testing.T) {
 		t.Fatalf("Error creating OpenAI client; %v", err)
 	}
 
-	db, err := NewInMemoryExampleDB(*cfg, client)
+	vectorizer := oai.NewVectorizer(client)
+	db, err := NewInMemoryExampleDB(*cfg, vectorizer)
 	if err != nil {
 		t.Fatalf("Error creating learner; %v", err)
 	}

--- a/app/pkg/llms/completer.go
+++ b/app/pkg/llms/completer.go
@@ -1,0 +1,12 @@
+package llms
+
+import (
+	"context"
+
+	"github.com/jlewi/foyle/protos/go/foyle/v1alpha1"
+)
+
+// Completer is an interface for generating completions
+type Completer interface {
+	Complete(ctx context.Context, systemPrompt string, message string) ([]*v1alpha1.Block, error)
+}

--- a/app/pkg/llms/doc.go
+++ b/app/pkg/llms/doc.go
@@ -1,0 +1,2 @@
+// Package llms defines common interfaces for working with LLMS.
+package llms

--- a/app/pkg/llms/errors.go
+++ b/app/pkg/llms/errors.go
@@ -1,0 +1,9 @@
+package llms
+
+type ContextLengthExceededError struct {
+	Cause error
+}
+
+func (e ContextLengthExceededError) Error() string {
+	return e.Cause.Error()
+}

--- a/app/pkg/llms/vectorizer.go
+++ b/app/pkg/llms/vectorizer.go
@@ -1,0 +1,15 @@
+package llms
+
+import (
+	"context"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+// Vectorizer computes embedding representations of text.
+type Vectorizer interface {
+	// Embed computes the embedding of the text
+	Embed(ctx context.Context, text string) (*mat.VecDense, error)
+	// Length returns the length of the embeddings
+	Length() int
+}

--- a/app/pkg/oai/completer.go
+++ b/app/pkg/oai/completer.go
@@ -1,0 +1,97 @@
+package oai
+
+import (
+	"context"
+
+	"github.com/jlewi/foyle/app/pkg/config"
+	"github.com/jlewi/foyle/app/pkg/docs"
+	"github.com/jlewi/foyle/app/pkg/llms"
+	"github.com/jlewi/foyle/app/pkg/logs"
+	"github.com/jlewi/foyle/protos/go/foyle/v1alpha1"
+	"github.com/pkg/errors"
+	"github.com/sashabaranov/go-openai"
+)
+
+const (
+	temperature = 0.9
+)
+
+func NewCompleter(cfg config.Config, client *openai.Client) (*Completer, error) {
+	return &Completer{
+		client: client,
+		config: cfg,
+	}, nil
+}
+
+// Completer is a wrapper around OpenAI that implements the Completer interface.
+type Completer struct {
+	client *openai.Client
+	config config.Config
+}
+
+// Complete returns a ContextLengthExceededError if the context is too long
+func (c *Completer) Complete(ctx context.Context, systemPrompt string, message string) ([]*v1alpha1.Block, error) {
+	log := logs.FromContext(ctx)
+	messages := []openai.ChatCompletionMessage{
+		{Role: openai.ChatMessageRoleSystem,
+			Content: systemPrompt,
+		},
+		{Role: openai.ChatMessageRoleUser,
+			Content: message,
+		},
+	}
+	request := openai.ChatCompletionRequest{
+		Model:       c.config.GetModel(),
+		Messages:    messages,
+		MaxTokens:   2000,
+		Temperature: temperature,
+	}
+
+	log.Info("OpenAI:CreateChatCompletion", "request", request)
+	resp, err := c.client.CreateChatCompletion(ctx, request)
+
+	if err != nil {
+		if ErrorIs(err, ContextLengthExceededCode) {
+			return nil, llms.ContextLengthExceededError{Cause: err}
+		}
+		// TODO(jeremy): Should we surface the error to the user as blocks in the notebook
+		return nil, errors.Wrapf(err, "CreateChatCompletion failed")
+	}
+
+	log.Info("OpenAI:CreateChatCompletion response", "resp", resp)
+
+	blocks, err := c.parseResponse(ctx, &resp)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to parse response")
+	}
+	return blocks, nil
+}
+
+func (c *Completer) parseResponse(ctx context.Context, resp *openai.ChatCompletionResponse) ([]*v1alpha1.Block, error) {
+	log := logs.FromContext(ctx)
+	allBlocks := make([]*v1alpha1.Block, 0, 10)
+	for _, choice := range resp.Choices {
+		if choice.Message.Content == "" {
+			continue
+		}
+
+		blocks, err := docs.MarkdownToBlocks(choice.Message.Content)
+		if err != nil {
+			log.Error(err, "Failed to parse markdown to blocks", "markdown", choice.Message.Content)
+			b := &v1alpha1.Block{
+				Kind:     v1alpha1.BlockKind_MARKUP,
+				Contents: choice.Message.Content,
+			}
+			allBlocks = append(allBlocks, b)
+			continue
+		}
+
+		// Set block ids
+		if _, err := docs.SetBlockIds(blocks); err != nil {
+			return nil, errors.Wrapf(err, "Failed to set block ids")
+		}
+
+		allBlocks = append(allBlocks, blocks...)
+	}
+	return allBlocks, nil
+}

--- a/app/pkg/oai/embeddings.go
+++ b/app/pkg/oai/embeddings.go
@@ -1,0 +1,55 @@
+package oai
+
+import (
+	"context"
+
+	"github.com/jlewi/foyle/app/pkg/logs"
+	"github.com/pkg/errors"
+	"github.com/sashabaranov/go-openai"
+	"gonum.org/v1/gonum/mat"
+)
+
+func NewVectorizer(client *openai.Client) *Vectorizer {
+	return &Vectorizer{
+		client: client,
+	}
+}
+
+type Vectorizer struct {
+	client *openai.Client
+}
+
+func (v *Vectorizer) Embed(ctx context.Context, text string) (*mat.VecDense, error) {
+	log := logs.FromContext(ctx)
+	log.Info("RAG Query", "query", text)
+	request := openai.EmbeddingRequestStrings{
+		Input:          []string{text},
+		Model:          openai.SmallEmbedding3,
+		User:           "",
+		EncodingFormat: "float",
+	}
+
+	resp, err := v.client.CreateEmbeddings(ctx, request)
+	if err != nil {
+		return nil, errors.Errorf("Failed to create embeddings")
+	}
+
+	if len(resp.Data) != 1 {
+		return nil, errors.Errorf("Expected exactly 1 embedding but got %d", len(resp.Data))
+	}
+
+	if len(resp.Data[0].Embedding) != SmallEmbeddingsDims {
+		return nil, errors.Errorf("Embeddings have wrong dimension; got %v, want %v", len(resp.Data[0].Embedding), SmallEmbeddingsDims)
+	}
+
+	// Compute the cosine similarity between the query and each example.
+	qVec := mat.NewVecDense(SmallEmbeddingsDims, nil)
+	for i := 0; i < SmallEmbeddingsDims; i++ {
+		qVec.SetVec(i, float64(resp.Data[0].Embedding[i]))
+	}
+	return qVec, nil
+}
+
+func (v *Vectorizer) Length() int {
+	return SmallEmbeddingsDims
+}


### PR DESCRIPTION
* Define two higher level interfaces Completer and Vectorizer to handle generating completions and computting embeddings.

* This will make it easier to support different LLM providers because we can just implement those interfaces for new providers.

Related to #158