### PR TITLE
Support using Replicate

### DIFF
--- a/app/api/config.go
+++ b/app/api/config.go
@@ -1,8 +1,18 @@
 package api
 
+type ModelProvider string
+
+const (
+	ModelProviderReplicate ModelProvider = "replicate"
+	ModelProviderOpenAI    ModelProvider = "openai"
+	ModelProviderDefault   ModelProvider = "openai"
+)
+
 type AgentConfig struct {
 	// Model is the name of the model to use to generate completions
 	Model string `json:"model" yaml:"model"`
+	// ModelProvider is the provider of the model
+	ModelProvider ModelProvider `json:"modelProvider" yaml:"modelProvider"`
 
 	// RAG is the configuration for the RAG model
 	RAG *RAGConfig `json:"rag,omitempty" yaml:"rag,omitempty"`

--- a/app/go.mod
+++ b/app/go.mod
@@ -154,6 +154,7 @@ require (
 	github.com/prometheus/client_model v0.2.1-0.20210607210712-147c58e9608a // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/replicate/replicate-go v0.21.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect

--- a/app/go.sum
+++ b/app/go.sum
@@ -477,6 +477,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/replicate/replicate-go v0.21.0 h1:37eWInQH7rRr14Epj5axfh/Iko+vsOqsS1JKm9DEhr4=
+github.com/replicate/replicate-go v0.21.0/go.mod h1:D2x8SztjeUKcaYnSgVu3H2DechufLJWZJB4+TLA3Rag=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/app/pkg/config/config.go
+++ b/app/pkg/config/config.go
@@ -57,6 +57,8 @@ type Config struct {
 	Eval *EvalConfig `json:"eval,omitempty" yaml:"eval,omitempty"`
 
 	Learner *LearnerConfig `json:"learner,omitempty" yaml:"learner,omitempty"`
+
+	Replicate *ReplicateConfig `json:"replicate,omitempty" yaml:"replicate,omitempty"`
 }
 
 type LearnerConfig struct {
@@ -101,6 +103,11 @@ type OpenAIConfig struct {
 
 	// BaseURL is the baseURL for the API.
 	BaseURL string `json:"baseURL" yaml:"baseURL"`
+}
+
+type ReplicateConfig struct {
+	// APIKeyFile is the path to the file containing the API key
+	APIKeyFile string `json:"apiKeyFile" yaml:"apiKeyFile"`
 }
 
 type AzureOpenAIConfig struct {

--- a/app/pkg/replicate/client.go
+++ b/app/pkg/replicate/client.go
@@ -1,0 +1,24 @@
+package replicate
+
+import (
+	"github.com/jlewi/foyle/app/pkg/config"
+	"github.com/jlewi/monogo/files"
+	"github.com/pkg/errors"
+	repGo "github.com/replicate/replicate-go"
+	"strings"
+)
+
+func NewClient(cfg config.Config) (*repGo.Client, error) {
+	if cfg.Replicate == nil {
+		return nil, errors.New("Replicate config is nil; You must configure the replicate model provider to create a replicate client")
+	}
+	token, err := files.Read(cfg.Replicate.APIKeyFile)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to read Replicate API token from file %s", cfg.Replicate.APIKeyFile)
+	}
+	r8, err := repGo.NewClient(repGo.WithToken(strings.TrimSpace(string(token))))
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to create Replicate client")
+	}
+	return r8, nil
+}

--- a/app/pkg/replicate/client.go
+++ b/app/pkg/replicate/client.go
@@ -1,12 +1,23 @@
 package replicate
 
 import (
+	"github.com/go-logr/zapr"
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/jlewi/foyle/app/pkg/config"
 	"github.com/jlewi/monogo/files"
 	"github.com/pkg/errors"
 	repGo "github.com/replicate/replicate-go"
+	"github.com/sashabaranov/go-openai"
+	"go.uber.org/zap"
 	"strings"
 )
+
+const (
+	// ChatProxyBaseURL is the URL of the chat proxy for LLAMA on Replicate
+	ChatProxyBaseURL = "https://openai-proxy.replicate.com/v1"
+)
+
+// TODO(jeremy): Should we implement an HTTP client with retries for the Replicate client?
 
 func NewClient(cfg config.Config) (*repGo.Client, error) {
 	if cfg.Replicate == nil {
@@ -21,4 +32,47 @@ func NewClient(cfg config.Config) (*repGo.Client, error) {
 		return nil, errors.Wrapf(err, "Failed to create Replicate client")
 	}
 	return r8, nil
+}
+
+// NewChatClient helper function to create a new OpenAI client from  a config
+func NewChatClient(cfg config.Config) (*openai.Client, error) {
+	if cfg.Replicate == nil {
+		return nil, errors.New("Replicate config is nil; You must configure the replicate model provider to create a replicate client")
+	}
+	log := zapr.NewLogger(zap.L())
+	// ************************************************************************
+	// Setup middleware
+	// ************************************************************************
+
+	// Handle retryable errors
+	// To handle retryable errors we use hashi corp's retryable client. This client will automatically retry on
+	// retryable errors like 429; rate limiting
+	retryClient := retryablehttp.NewClient()
+	httpClient := retryClient.StandardClient()
+
+	var clientConfig openai.ClientConfig
+	log.Info("Configuring Replicate LLAMA chat proxy client")
+
+	apiKey := ""
+	if cfg.Replicate.APIKeyFile != "" {
+		var err error
+		apiBytes, err := files.Read(cfg.Replicate.APIKeyFile)
+		if err != nil {
+			return nil, err
+		}
+		apiKey = strings.TrimSpace(string(apiBytes))
+	}
+
+	if apiKey == "" {
+		return nil, errors.New("APIKeyFile is required")
+	}
+	clientConfig = openai.DefaultConfig(apiKey)
+
+	log.Info("Using Replicate chat proxy baseURL", "baseURL", ChatProxyBaseURL)
+	clientConfig.BaseURL = ChatProxyBaseURL
+
+	clientConfig.HTTPClient = httpClient
+	client := openai.NewClientWithConfig(clientConfig)
+
+	return client, nil
 }

--- a/app/pkg/replicate/client.go
+++ b/app/pkg/replicate/client.go
@@ -1,6 +1,8 @@
 package replicate
 
 import (
+	"strings"
+
 	"github.com/go-logr/zapr"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/jlewi/foyle/app/pkg/config"
@@ -9,7 +11,6 @@ import (
 	repGo "github.com/replicate/replicate-go"
 	"github.com/sashabaranov/go-openai"
 	"go.uber.org/zap"
-	"strings"
 )
 
 const (

--- a/app/pkg/replicate/completer.go
+++ b/app/pkg/replicate/completer.go
@@ -1,0 +1,27 @@
+package replicate
+
+import (
+	"github.com/go-logr/zapr"
+	"github.com/jlewi/foyle/app/api"
+	"github.com/jlewi/foyle/app/pkg/config"
+	"github.com/jlewi/foyle/app/pkg/oai"
+	"github.com/sashabaranov/go-openai"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultModel = "meta/meta-llama-3-8b-instruct"
+)
+
+func NewCompleter(cfg config.Config, client *openai.Client) (*oai.Completer, error) {
+	log := zapr.NewLogger(zap.L())
+	if cfg.Agent == nil {
+		cfg.Agent = &api.AgentConfig{}
+	}
+	if cfg.Agent == nil || cfg.Agent.Model == "" {
+
+		log.Info("No model specified; using default model", "model", defaultModel)
+		cfg.Agent.Model = "meta/meta-llama-3-8b-instruct"
+	}
+	return oai.NewCompleter(cfg, client)
+}

--- a/app/pkg/replicate/completer_test.go
+++ b/app/pkg/replicate/completer_test.go
@@ -1,0 +1,44 @@
+package replicate
+
+import (
+	"context"
+	"github.com/jlewi/foyle/app/pkg/config"
+	"github.com/jlewi/foyle/app/pkg/docs"
+	"os"
+	"testing"
+)
+
+func Test_ReplicateCompleter(t *testing.T) {
+	if os.Getenv("GITHUB_ACTIONS") != "" {
+		t.Skipf("Test is skipped in GitHub actions")
+	}
+
+	cfg := config.Config{
+		Replicate: &config.ReplicateConfig{
+			APIKeyFile: "/Users/jlewi/replicate/secrets/apikey",
+		},
+	}
+
+	client, err := NewChatClient(cfg)
+	if err != nil {
+		t.Fatalf("Error creating client; %v", err)
+	}
+
+	completer, err := NewCompleter(cfg, client)
+	if err != nil {
+		t.Fatalf("Error creating completer; %v", err)
+	}
+
+	systemPrompt := "You are a cloud expert. Help the user with the following task"
+	message := "Use gcloud to list buckets"
+	result, err := completer.Complete(context.Background(), systemPrompt, message)
+	if err != nil {
+		t.Fatalf("Error completing text; %v", err)
+	}
+
+	if len(result) == 0 {
+		t.Fatalf("Complete returned no results")
+	}
+
+	t.Logf("Result:\n%v", docs.BlocksToMarkdown(result))
+}

--- a/app/pkg/replicate/completer_test.go
+++ b/app/pkg/replicate/completer_test.go
@@ -2,10 +2,11 @@ package replicate
 
 import (
 	"context"
-	"github.com/jlewi/foyle/app/pkg/config"
-	"github.com/jlewi/foyle/app/pkg/docs"
 	"os"
 	"testing"
+
+	"github.com/jlewi/foyle/app/pkg/config"
+	"github.com/jlewi/foyle/app/pkg/docs"
 )
 
 func Test_ReplicateCompleter(t *testing.T) {

--- a/app/pkg/replicate/vectorizer.go
+++ b/app/pkg/replicate/vectorizer.go
@@ -1,0 +1,93 @@
+package replicate
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/go-logr/zapr"
+	"github.com/pkg/errors"
+	"github.com/replicate/replicate-go"
+	repGo "github.com/replicate/replicate-go"
+	"go.uber.org/zap"
+	"gonum.org/v1/gonum/mat"
+)
+
+const (
+	vectorLength = 1024
+)
+
+func NewVectorizer(client *repGo.Client) (*Vectorizer, error) {
+	return &Vectorizer{client: client}, nil
+}
+
+// Vectorizer computes embedding representations of text using models on replicate
+type Vectorizer struct {
+	client *repGo.Client
+}
+
+func (v *Vectorizer) Embed(ctx context.Context, text string) (*mat.VecDense, error) {
+	log := zapr.NewLogger(zap.L())
+
+	model := "replicate/retriever-embeddings"
+	version := "9cf9f015a9cb9c61d1a2610659cdac4a4ca222f2d3707a68517b18c198a9add1"
+	modelVersion := model + ":" + version
+	texts, err := json.Marshal([]string{text})
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to marshal text")
+	}
+	input := replicate.PredictionInput{
+		"texts":                string(texts),
+		"convert_to_numpy":     false,
+		"normalize_embeddings": true,
+	}
+
+	id, err := repGo.ParseIdentifier(modelVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	if id.Version == nil {
+		return nil, errors.New("version must be specified")
+	}
+
+	prediction, err := v.client.CreatePrediction(ctx, *id.Version, input, nil, false)
+	if err != nil {
+		return nil, err
+	}
+
+	err = v.client.Wait(ctx, prediction)
+
+	if prediction.Status != "succeeded" {
+		log.Error(errors.New("Prediction failed"), "Prediction failed", "prediction", prediction)
+		return nil, errors.Errorf("Prediction failed; %+v", prediction.Error)
+	}
+
+	// The return type is [][]interface{}
+	arrays, ok := prediction.Output.([]interface{})
+
+	if !ok {
+		return nil, errors.New("Failed to convert output to array")
+	}
+
+	if len(arrays) != 1 {
+		return nil, errors.Errorf("Expected exactly 1 array but got %d", len(arrays))
+	}
+
+	array, ok := arrays[0].([]interface{})
+	if !ok {
+		return nil, errors.New("Failed to convert output to float64")
+	}
+	vec := make([]float64, 0, len(array))
+	for _, v := range array {
+		f, ok := v.(float64)
+		if !ok {
+			return nil, errors.New("Failed to convert output to float64")
+		}
+		vec = append(vec, f)
+
+	}
+	return mat.NewVecDense(vectorLength, vec), nil
+}
+
+func (v *Vectorizer) Length() int {
+	return vectorLength
+}

--- a/app/pkg/replicate/vectorizer.go
+++ b/app/pkg/replicate/vectorizer.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-logr/zapr"
 	"github.com/pkg/errors"
 	"github.com/replicate/replicate-go"
-	repGo "github.com/replicate/replicate-go"
 	"go.uber.org/zap"
 	"gonum.org/v1/gonum/mat"
 )
@@ -15,13 +14,13 @@ const (
 	vectorLength = 1024
 )
 
-func NewVectorizer(client *repGo.Client) (*Vectorizer, error) {
+func NewVectorizer(client *replicate.Client) (*Vectorizer, error) {
 	return &Vectorizer{client: client}, nil
 }
 
 // Vectorizer computes embedding representations of text using models on replicate
 type Vectorizer struct {
-	client *repGo.Client
+	client *replicate.Client
 }
 
 func (v *Vectorizer) Embed(ctx context.Context, text string) (*mat.VecDense, error) {
@@ -40,7 +39,7 @@ func (v *Vectorizer) Embed(ctx context.Context, text string) (*mat.VecDense, err
 		"normalize_embeddings": true,
 	}
 
-	id, err := repGo.ParseIdentifier(modelVersion)
+	id, err := replicate.ParseIdentifier(modelVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/app/pkg/replicate/vectorizer_test.go
+++ b/app/pkg/replicate/vectorizer_test.go
@@ -1,0 +1,44 @@
+package replicate
+
+import (
+	"context"
+	"github.com/jlewi/foyle/app/pkg/config"
+	"os"
+	"testing"
+)
+
+func TestVectorizer_Embed(t *testing.T) {
+	if os.Getenv("GITHUB_ACTIONS") != "" {
+		t.Skip("Skipping test on GitHub Actions.")
+	}
+
+	cfg := config.Config{
+		Replicate: &config.ReplicateConfig{
+			APIKeyFile: "/Users/jlewi/replicate/secrets/apikey",
+		},
+	}
+
+	client, err := NewClient(cfg)
+
+	if err != nil {
+		t.Fatalf("Error creating client; %v", err)
+	}
+
+	v, err := NewVectorizer(client)
+	if err != nil {
+		t.Fatalf("Error creating vectorizer; %v", err)
+	}
+
+	result, err := v.Embed(context.Background(), "Hello World")
+	if err != nil {
+		t.Fatalf("Error embedding text; %v", err)
+	}
+
+	if result == nil {
+		t.Fatalf("Embed returned nil")
+	}
+
+	if result.Len() != v.Length() {
+		t.Fatalf("Expected length of %d; got %d", v.Length(), result.Len())
+	}
+}

--- a/app/pkg/replicate/vectorizer_test.go
+++ b/app/pkg/replicate/vectorizer_test.go
@@ -2,9 +2,10 @@ package replicate
 
 import (
 	"context"
-	"github.com/jlewi/foyle/app/pkg/config"
 	"os"
 	"testing"
+
+	"github.com/jlewi/foyle/app/pkg/config"
 )
 
 func TestVectorizer_Embed(t *testing.T) {

--- a/docs/content/en/docs/replicate/_index.md
+++ b/docs/content/en/docs/replicate/_index.md
@@ -1,0 +1,47 @@
+---
+title: "LLAMA3 on Replicate"
+description: "Using LLAMA3 on Replicate with Foyle"
+weight: 4
+---
+
+## What You'll Learn
+
+How to configure Foyle to use [LLAMA3 hosted on Replicate](https://replicate.com/meta/meta-llama-3-8b-instruct?input=http)
+
+## Prerequisites
+
+1. You need a [Replicate account](https://replicate.com/docs)
+
+## Setup Foyle To Use LLAMA3 on Replicate
+
+1. Get an [API Token from Replicate](https://replicate.com/signin?next=/account/api-tokens) and save it to a file
+
+1. Configure Foyle to use this API key
+
+```
+foyle config set replicate.apiKeyFile=/path/to/your/key/file
+```
+1. Configure Foyle to use [LLAMA3 hosted on Replicate](https://replicate.com/meta/meta-llama-3-8b-instruct?input=http)
+
+1. Configure Foyle to use the appropriate model deployments
+
+```
+foyle config set  agent.model=meta/meta-llama-3-8b-instruct
+foyle config set  agent.modelProvider=replicate                
+```
+
+## How It Works
+
+Foyle uses 2 Models
+
+* A Chat model to generate completions
+* An embedding model to compute embeddings for RAG
+
+Replicate provides hosted versions of [meta/llama-3-8b-instruct](https://replicate.com/meta/meta-llama-3-8b-instruct) 
+and [meta/llama-3-8b-instruct](https://replicate.com/meta/meta-llama-3-70b-instruct) which are chat models. Notably,
+these models are kept warm so when you send predictions Replicate doesn't need to boot up new instances leading to
+long latencies. Replicate also provides an [OpenAI proxy](https://lifeboat.replicate.dev/) so you can use the OpenAI
+APIs to generate responses.
+
+Unfortunately, Replicate doesn't provide hosted, always versions of the embedding models. So Foyle continues to
+use OpenAI for the embedding models.

--- a/docs/content/en/docs/replicate/_index.md
+++ b/docs/content/en/docs/replicate/_index.md
@@ -39,9 +39,9 @@ Foyle uses 2 Models
 
 Replicate provides hosted versions of [meta/llama-3-8b-instruct](https://replicate.com/meta/meta-llama-3-8b-instruct) 
 and [meta/llama-3-8b-instruct](https://replicate.com/meta/meta-llama-3-70b-instruct) which are chat models. Notably,
-these models are kept warm so when you send predictions Replicate doesn't need to boot up new instances leading to
-long latencies. Replicate also provides an [OpenAI proxy](https://lifeboat.replicate.dev/) so you can use the OpenAI
+these models are kept warm so when you send predictions Replicate doesn't need to boot up new instances. 
+Replicate also provides an [OpenAI proxy](https://lifeboat.replicate.dev/) so you can use the OpenAI
 APIs to generate responses.
 
-Unfortunately, Replicate doesn't provide hosted, always versions of the embedding models. So Foyle continues to
+Unfortunately, Replicate doesn't provide hosted, always warms versions of embedding models. So Foyle continues to
 use OpenAI for the embedding models.


### PR DESCRIPTION
* Implement the completer and vectorizer interfaces for Replicate
* For the completer API we can use Replicate's OpenAI proxy to access LLAMA3 https://lifeboat.replicate.dev/
* There are embedding models on Replicate but they aren't kept warmed up so they are super slow
   so we should probably use an embedding model from someplace else.
   * Good example of why we don't want to source models from a single provider.

Anthropic recommends voyage AI
https://www.voyageai.com/?ref=anthropic

Related to #158 