### PR TITLE
Minor bugfixes

### DIFF
--- a/app/pkg/analyze/analyzer.go
+++ b/app/pkg/analyze/analyzer.go
@@ -485,7 +485,8 @@ func findLogFiles(ctx context.Context, logsDir string) ([]string, error) {
 	paths := map[string]bool{}
 
 	if _, err := os.Stat(logsDir); err != nil && os.IsNotExist(err) {
-		return jsonFiles, fmt.Errorf("Analyze invoked for non-existent path: %v", logsDir)
+
+		return jsonFiles, errors.WithStack(fmt.Errorf("Analyze invoked for non-existent path: %v", logsDir))
 	}
 
 	// Walk the directory and add all JSON files.

--- a/app/pkg/application/app.go
+++ b/app/pkg/application/app.go
@@ -567,8 +567,10 @@ func (a *App) Shutdown() error {
 	l := zap.L()
 	log := zapr.NewLogger(l)
 
-	if err := a.analyzer.Shutdown(context.Background()); err != nil {
-		log.Error(err, "Error shutting down analyzer")
+	if a.analyzer != nil {
+		if err := a.analyzer.Shutdown(context.Background()); err != nil {
+			log.Error(err, "Error shutting down analyzer")
+		}
 	}
 
 	// Analyzer should be shutdown before the learner because analyzer tries to enqueue learner items


### PR DESCRIPTION
* App.shutdown should ensure Analyzer is non-nill before invoking it; otherwise we get a nill pointer dereference

* Analzyer should include a stack trace in its error message.