### PR TITLE
Give each streaming generate request a unique trace id

### DIFF
--- a/app/pkg/agent/agent.go
+++ b/app/pkg/agent/agent.go
@@ -2,10 +2,11 @@ package agent
 
 import (
 	"context"
-	"go.opentelemetry.io/otel/attribute"
 	"io"
 	"strings"
 	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
 
 	"connectrpc.com/connect"
 	"github.com/jlewi/foyle/app/pkg/runme/converters"

--- a/app/pkg/agent/tracer.go
+++ b/app/pkg/agent/tracer.go
@@ -1,0 +1,10 @@
+package agent
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func tracer() trace.Tracer {
+	return otel.Tracer("github.com/jlewi/foyle/app/pkg/agent")
+}

--- a/app/pkg/analyze/analyzer_test.go
+++ b/app/pkg/analyze/analyzer_test.go
@@ -196,19 +196,20 @@ func Test_BuildBlockLog(t *testing.T) {
 
 	// We shuffle ExecTraceIds to make sure we properly set block log based on the later trace
 	execTraceIds := shuffle([]string{execTrace1.GetId(), execTrace2.GetId()})
+
 	cases := []testCase{
 		{
 			name: "basic",
 			block: &logspb.BlockLog{
-				Id:         bid1,
-				GenTraceId: genTrace.Id,
-
+				Id:           bid1,
+				GenTraceId:   genTrace.Id,
 				ExecTraceIds: execTraceIds,
 			},
 			expected: &logspb.BlockLog{
-				Id:             bid1,
-				GenTraceId:     genTrace.Id,
-				ExecTraceIds:   execTraceIds,
+				Id:         bid1,
+				GenTraceId: genTrace.Id,
+				// ExecTraceIds should be sorted by the timestamp
+				ExecTraceIds:   []string{execTrace1.GetId(), execTrace2.GetId()},
 				Doc:            genTrace.GetGenerate().Request.Doc,
 				GeneratedBlock: genTrace.GetGenerate().Response.Blocks[0],
 				ExecutedBlock:  execTrace2.GetExecute().Request.Block,


### PR DESCRIPTION
First step of fixing tracing and learning to work with streaming.
We need to give each generate request within a streaming request a unique trace id.

Related to #180
Related to #167 