### PR TITLE
Increase buffer size to fix bufio.Scanner: token too long

### DIFF
--- a/app/pkg/analyze/reader.go
+++ b/app/pkg/analyze/reader.go
@@ -24,6 +24,14 @@ func readLinesFromOffset(ctx context.Context, path string, offset int64) ([]stri
 
 	var lines []string
 	scanner := bufio.NewScanner(f)
+	// Allocate an initial buffer of 5MB
+	initialBuffer := make([]byte, 0, 5*1024*1024)
+	// Allow up to a maximum size of 64 MB. If the token size is larger than this we will get an error.
+	// Our lines should be O(size of our markdown files) because a log entry could contain an entire markdown file.
+	// Most of our file are less than 1 MB. Empirically I observed that the longest line length in some file was
+	// 772685 characters
+	maxBuffer := 64 * 1024 * 1024
+	scanner.Buffer(initialBuffer, maxBuffer)
 	scanner.Split(ScanLinesNoPartial)
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/app/pkg/analyze/reader_test.go
+++ b/app/pkg/analyze/reader_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/jlewi/monogo/helpers"
+
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -84,5 +86,38 @@ func Test_readFromOffset(t *testing.T) {
 	}
 	if d := cmp.Diff(lastLine, []string{"line 5"}); d != "" {
 		t.Errorf("unexpected lines:\n%v", d)
+	}
+}
+
+func Test_readReallyLongLines(t *testing.T) {
+	f, err := os.CreateTemp("", "readReallyLongLines.log")
+	if err != nil {
+		t.Fatal(err)
+
+	}
+
+	maxLength := 2 * 1000 * 1000
+	data, err := helpers.RandString(maxLength)
+	if err != nil {
+		t.Fatalf("Failed to generate random string: %v", err)
+	}
+
+	if _, err := f.WriteString(data + "\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	filePath := f.Name()
+
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	lines, _, err := readLinesFromOffset(context.Background(), filePath, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if lines[0] != data {
+		t.Fatalf("Read line doesn't match written line")
 	}
 }


### PR DESCRIPTION
* In actual use we are starting to see bufio.Scanner errors from the analyzer

```
2024-08-06T12:50:15.653-0700    ERROR   analyze/analyzer.go:189 Error processing log file       {"path": "/Users/jlewi/.foyle/logs/raw/foyle.logs.2024-08-06T09:33:33.json", "error": "failed to scan file /Users/jlewi/.foyle/logs/raw/foyle.logs.2024-08-06T09:33:33.json: bufio.Scanner: token too long", "errorVerbose": "bufio.Scanner: token too long\nfailed to scan file /Users/jlewi/.foyle/logs/raw/foyle.logs.2024-08-06T09:33:33.json\ngithub.com/jlewi/foyle/app/pkg/analyze.readLinesFromOffset\n\t/Users/jlewi/git_foyle/app/pkg/analyze/reader.go:35\ngithub.com/jlewi/foyle/app/pkg/analyze.(*Analyzer).processLogFile\n\t/Users/jlewi/git_foyle/app/pkg/analyze/analyzer.go:203\ngithub.com/jlewi/foyle/app/pkg/analyze.(*Analyzer).handleLogFileEvents.func1\n\t/Users/jlewi/git_foyle/app/pkg/analyze/analyzer.go:188\ngithub.com/jlewi/foyle/app/pkg/analyze.(*Analyzer).handleLogFileEvents\n\t/Users/jlewi/git_foyle/app/pkg/analyze/analyzer.go:194\nruntime.goexit\n\t/opt/homebrew/opt/go/libexec/src/runtime/asm_arm64.s:1222"}
```

This is because the buffer used by the Scanner limits the max token size and the default buffer is smaller then our longest log lines.

Since we are potentially logging the entire markdown document, our log lines can O(size of markdown file).

So to fix this we allocate a larger buffer.