### PR TITLE
Fix panic and error reporting in learner.Reconcile. 

### DIFF
--- a/app/pkg/learn/learner.go
+++ b/app/pkg/learn/learner.go
@@ -200,7 +200,7 @@ func (l *Learner) Reconcile(ctx context.Context, id string) error {
 			return nil
 		}()
 		if writeErr != nil {
-			writeErrors.AddCause(err)
+			writeErrors.AddCause(writeErr)
 			continue
 		}
 		// All post a single file because we don't need to read it multiple times


### PR DESCRIPTION
We weren't adding the correct error to the list of errors that got reported. We ended up adding a nil error which caused panics down the line.