### PR TITLE
Don't hide the error when reconciling examples.

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/honeycombio/otel-config-go v1.15.0
 	github.com/jlewi/foyle/protos/go v0.0.0-00010101000000-000000000000
 	github.com/jlewi/hydros v0.0.7-0.20240503183011-8f99ead373fb
-	github.com/jlewi/monogo v0.0.0-20240621212541-14462684ce69
+	github.com/jlewi/monogo v0.0.0-20240826232127-814ce2b6c0b9
 	github.com/liushuangls/go-anthropic/v2 v2.4.1
 	github.com/maxence-charriere/go-app/v9 v9.8.0
 	github.com/oklog/ulid/v2 v2.1.0

--- a/app/go.sum
+++ b/app/go.sum
@@ -385,6 +385,10 @@ github.com/jlewi/monogo v0.0.0-20240621134004-bb6520225771 h1:V6Ek4ZqTMG8iYF6azw
 github.com/jlewi/monogo v0.0.0-20240621134004-bb6520225771/go.mod h1:s3nTD+owHZ6b+F13JdSpXLtrAH35pOqdwdcZEZ/gwBc=
 github.com/jlewi/monogo v0.0.0-20240621212541-14462684ce69 h1:E13AbOWwrGoFiOcoK+EeSdlXede0nnIuzswgXOT/PYM=
 github.com/jlewi/monogo v0.0.0-20240621212541-14462684ce69/go.mod h1:s3nTD+owHZ6b+F13JdSpXLtrAH35pOqdwdcZEZ/gwBc=
+github.com/jlewi/monogo v0.0.0-20240822232451-ee70c5f8e5fb h1:PePq6KauWq5ntUe/sdOGOqk99v3p3dNCytIaGM0i/ts=
+github.com/jlewi/monogo v0.0.0-20240822232451-ee70c5f8e5fb/go.mod h1:s3nTD+owHZ6b+F13JdSpXLtrAH35pOqdwdcZEZ/gwBc=
+github.com/jlewi/monogo v0.0.0-20240826232127-814ce2b6c0b9 h1:a+B3B/9suHv+8LfXKvrxMKWUtH+75BKfvmwkeyKCTSA=
+github.com/jlewi/monogo v0.0.0-20240826232127-814ce2b6c0b9/go.mod h1:s3nTD+owHZ6b+F13JdSpXLtrAH35pOqdwdcZEZ/gwBc=
 github.com/jlewi/runme/v3 v3.0.0-20240524042602-a01f865c4617 h1:lyXrThCive3plQ/HyiYvklcdQ6F84bZ7DX+dMU01iik=
 github.com/jlewi/runme/v3 v3.0.0-20240524042602-a01f865c4617/go.mod h1:RSMUWGN5b1i4eXEAKbuksB/z8thptDXVKyZ6lRXMcJc=
 github.com/jlewi/runme/v3 v3.0.0-20240524044247-2657f0b08e0f h1:NFOdz6g8E44q5RPLXbUQBK+Ox+3tRqk+NG+rTXWHgcY=

--- a/app/pkg/learn/learner.go
+++ b/app/pkg/learn/learner.go
@@ -187,7 +187,7 @@ func (l *Learner) Reconcile(ctx context.Context, id string) error {
 			}
 			w, err := helper.NewWriter(expectedFile)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "Failed to create writer for example %s; to file %s", b.GetId(), expectedFile)
 			}
 			if closer, ok := w.(io.Closer); ok {
 				defer closer.Close()
@@ -212,8 +212,8 @@ func (l *Learner) Reconcile(ctx context.Context, id string) error {
 	}
 
 	if len(writeErrors.Causes) > 0 {
+		writeErrors.Final = errors.New("Not all examples could be successfully reconciled")
 		return writeErrors
-
 	}
 	return nil
 }


### PR DESCRIPTION
* Upgrade monogo to pull in a fix https://github.com/jlewi/monogo/commit/814ce2b6c0b971be0ae3ec29542e7ec14775ffd9
* This was causing the panics when trying to get the errors for the reconciler
* Related to #208; 