### PR TITLE
Allow Example Files To Be Overwritten

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/honeycombio/otel-config-go v1.15.0
 	github.com/jlewi/foyle/protos/go v0.0.0-00010101000000-000000000000
 	github.com/jlewi/hydros v0.0.7-0.20240503183011-8f99ead373fb
-	github.com/jlewi/monogo v0.0.0-20240826232127-814ce2b6c0b9
+	github.com/jlewi/monogo v0.0.0-20240827035044-f4a3457933da
 	github.com/liushuangls/go-anthropic/v2 v2.4.1
 	github.com/maxence-charriere/go-app/v9 v9.8.0
 	github.com/oklog/ulid/v2 v2.1.0

--- a/app/go.sum
+++ b/app/go.sum
@@ -389,6 +389,8 @@ github.com/jlewi/monogo v0.0.0-20240822232451-ee70c5f8e5fb h1:PePq6KauWq5ntUe/sd
 github.com/jlewi/monogo v0.0.0-20240822232451-ee70c5f8e5fb/go.mod h1:s3nTD+owHZ6b+F13JdSpXLtrAH35pOqdwdcZEZ/gwBc=
 github.com/jlewi/monogo v0.0.0-20240826232127-814ce2b6c0b9 h1:a+B3B/9suHv+8LfXKvrxMKWUtH+75BKfvmwkeyKCTSA=
 github.com/jlewi/monogo v0.0.0-20240826232127-814ce2b6c0b9/go.mod h1:s3nTD+owHZ6b+F13JdSpXLtrAH35pOqdwdcZEZ/gwBc=
+github.com/jlewi/monogo v0.0.0-20240827035044-f4a3457933da h1:SBE/ERHbNWTrXG5SNMGYNKIQ+HlCniPzAKB35QfNIu4=
+github.com/jlewi/monogo v0.0.0-20240827035044-f4a3457933da/go.mod h1:s3nTD+owHZ6b+F13JdSpXLtrAH35pOqdwdcZEZ/gwBc=
 github.com/jlewi/runme/v3 v3.0.0-20240524042602-a01f865c4617 h1:lyXrThCive3plQ/HyiYvklcdQ6F84bZ7DX+dMU01iik=
 github.com/jlewi/runme/v3 v3.0.0-20240524042602-a01f865c4617/go.mod h1:RSMUWGN5b1i4eXEAKbuksB/z8thptDXVKyZ6lRXMcJc=
 github.com/jlewi/runme/v3 v3.0.0-20240524044247-2657f0b08e0f h1:NFOdz6g8E44q5RPLXbUQBK+Ox+3tRqk+NG+rTXWHgcY=

--- a/app/pkg/learn/learner.go
+++ b/app/pkg/learn/learner.go
@@ -179,6 +179,8 @@ func (l *Learner) Reconcile(ctx context.Context, id string) error {
 
 	writeErrors := &helpers.ListOfErrors{}
 	posted := false
+	// An example can be saved in multiple locations.
+	// This supports sharing by allowing examples to be written to a shared bucket.
 	for _, expectedFile := range expectedFiles {
 		writeErr := func() error {
 			helper, err := l.factory.Get(expectedFile)
@@ -199,6 +201,8 @@ func (l *Learner) Reconcile(ctx context.Context, id string) error {
 			return nil
 		}()
 		if writeErr != nil {
+			// We need to log the individual error here so that its stack trace gets logged
+			log.Error(err, "Failed to write example", "id", b.GetId(), "file", expectedFile)
 			writeErrors.AddCause(writeErr)
 			continue
 		}


### PR DESCRIPTION
* An example file can be overwritten.
* A block could be executed multiple times. Each time a block is executed it could trigger feedback and learning. In this case, the learner would be invoked and we'd want to use the latest value of the cell to learn from.
* Prior to https://github.com/jlewi/monogo/pull/22 FileHelper.NewWriter would throw an error if the file already exists. That PR changed the semantics to truncate the file if it already exists.
* So by upgrading monogo we should allow overwriting of examples if they already exist.

Fix #205