### PR TITLE
Fix Race Condition In Learning

### DIFF
--- a/app/pkg/analyze/analyzer.go
+++ b/app/pkg/analyze/analyzer.go
@@ -459,6 +459,8 @@ func (a *Analyzer) processLogEvent(ctx context.Context, entry *api.LogEntry) {
 			log.Error(err, "Failed to update block with execution", "blockId", bid)
 		}
 		// We need to enqueue the block for processing since it was executed.
+		// The learner will decide whether the blockLog has all the information it needs otherwise it will
+		// disregard the block item and wait for further events.
 		if a.learnNotifier != nil {
 			if err := a.learnNotifier(bid); err != nil {
 				log.Error(err, "Error notifying block event", "blockId", bid)
@@ -655,6 +657,14 @@ func (a *Analyzer) handleBlockEvents(ctx context.Context) {
 			})
 			if err != nil {
 				log.Error(err, "Error processing block", "blockId", blockItem.id)
+			}
+			// We need to enqueue the block for processing since it was executed.
+			// The learner will decide whether the blockLog has all the information it needs otherwise it will
+			// disregard the block item and wait for further events.
+			if a.learnNotifier != nil {
+				if err := a.learnNotifier(blockItem.id); err != nil {
+					log.Error(err, "Error notifying block event", "blockId", blockItem.id)
+				}
 			}
 			if a.signalBlockDone != nil {
 				a.signalBlockDone <- blockItem.id


### PR DESCRIPTION
The problem is described in detail here
https://github.com/jlewi/foyle/issues/215#issuecomment-2356987795

In #241 I changed where the learner gets notified of a block to process. Rather notifiying it when updating a blockLog with the generated block, I moved the update to do it after an execution event was processed.

My assumption was that by the time the execution event gets processed the BlockLog has already been processed.

But that's not guaranteed because we read the log lines in chunks and only update the blocklog with the generated block after reading the entire chunk. However, the executed field of the blockLog is updated as soon as the line is processed. As a result, we were notifying the learner after the first execution event at which point the block log hasn't been updated with the generated log.

The solution is to notify the learner after execution events are processed and after generated events are processed. The learner will check if all required fields are present (i.e. both generated and executed block fields). If not the item is ignored.

Therefore to make our code less brittle and more robust we can just fire notifications to the learner after either event.

Related to #215