### PR TITLE
Enable RAG by default

### DIFF
--- a/app/pkg/analyze/session_builder_test.go
+++ b/app/pkg/analyze/session_builder_test.go
@@ -3,6 +3,8 @@ package analyze
 import (
 	"context"
 	"database/sql"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -40,7 +42,14 @@ func setup() (testTuple, error) {
 		return testTuple{}, errors.Wrapf(err, "failed to create config")
 	}
 
-	db, err := sql.Open(SQLLiteDriver, cfg.GetSessionsDB())
+	// If the directory doesn't exit opening the SQLLite database will fail.
+	sessionsDBFile := cfg.GetSessionsDB()
+	dbDir := filepath.Dir(sessionsDBFile)
+	if err := os.MkdirAll(dbDir, 0755); err != nil {
+		return testTuple{}, errors.Wrapf(err, "Failed to create directory: %v", dbDir)
+	}
+
+	db, err := sql.Open(SQLLiteDriver, sessionsDBFile)
 	if err != nil {
 		return testTuple{}, errors.Wrapf(err, "Failed to open database")
 	}

--- a/app/pkg/application/app.go
+++ b/app/pkg/application/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/jlewi/monogo/helpers"
 	"io"
 	"net/http"
 	"os"
@@ -380,7 +381,13 @@ func (a *App) SetupAnalyzer() (*analyze.Analyzer, error) {
 		return nil, errors.New("Config is nil; call LoadConfig first")
 	}
 
-	db, err := sql.Open(analyze.SQLLiteDriver, a.Config.GetSessionsDB())
+	// If the directory doesn't exit opening the SQLLite database will fail.
+	sessionsDBFile := a.Config.GetSessionsDB()
+	dbDir := filepath.Dir(sessionsDBFile)
+	if err := os.MkdirAll(dbDir, helpers.UserGroupAllPerm); err != nil {
+		return nil, errors.Wrapf(err, "Failed to create directory: %v", dbDir)
+	}
+	db, err := sql.Open(analyze.SQLLiteDriver, sessionsDBFile)
 
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to open database: %v", a.Config.GetSessionsDB())

--- a/app/pkg/application/app.go
+++ b/app/pkg/application/app.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/jlewi/monogo/helpers"
 	"io"
 	"net/http"
 	"os"
@@ -12,6 +11,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/jlewi/monogo/helpers"
 
 	gcplogs "github.com/jlewi/monogo/gcp/logging"
 

--- a/app/pkg/config/config.go
+++ b/app/pkg/config/config.go
@@ -388,8 +388,8 @@ func InitViperInstance(v *viper.Viper, cmd *cobra.Command) error {
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv() // read in environment variables that match
 
-	setAgentDefaults()
-	setServerDefaults()
+	setAgentDefaults(v)
+	setServerDefaults(v)
 
 	// We need to attach to the command line flag if it was specified.
 	keyToflagName := map[string]string{
@@ -440,7 +440,7 @@ func (c *Config) APIBaseURL() string {
 
 // GetConfig returns a configuration created from the viper configuration.
 func GetConfig() *Config {
-	if globalV != nil {
+	if globalV == nil {
 		// TODO(jeremy): Using a global variable to pass state between InitViper and GetConfig is wonky.
 		// It might be better to combine InitViper and GetConfig into a single command that returns a config object.
 		// This would also make viper an implementation detail of the config.
@@ -504,23 +504,23 @@ func (c *Config) Write(cfgFile string) error {
 	return yaml.NewEncoder(f).Encode(c)
 }
 
-func setServerDefaults() {
-	viper.SetDefault("server.bindAddress", "0.0.0.0")
-	viper.SetDefault("server.httpPort", defaultHTTPPort)
+func setServerDefaults(v *viper.Viper) {
+	v.SetDefault("server.bindAddress", "0.0.0.0")
+	v.SetDefault("server.httpPort", defaultHTTPPort)
 	// gRPC typically uses 50051. If we use that as the default we might end up conflicting with other gRPC services
 	// running by default.
-	viper.SetDefault("server.grpcPort", 9080)
+	v.SetDefault("server.grpcPort", 9080)
 
 	// See https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts
 	// If we start using really slow models we may need to bump these to avoid timeouts.
-	viper.SetDefault("server.httpMaxWriteTimeout", 1*time.Minute)
-	viper.SetDefault("server.httpMaxReadTimeout", 1*time.Minute)
+	v.SetDefault("server.httpMaxWriteTimeout", 1*time.Minute)
+	v.SetDefault("server.httpMaxReadTimeout", 1*time.Minute)
 }
 
-func setAgentDefaults() {
-	viper.SetDefault("agent.model", DefaultModel)
-	viper.SetDefault("agent.rag.enabled", defaultRagEnabled)
-	viper.SetDefault("agent.rag.maxResults", defaultMaxResults)
+func setAgentDefaults(v *viper.Viper) {
+	v.SetDefault("agent.model", DefaultModel)
+	v.SetDefault("agent.rag.enabled", defaultRagEnabled)
+	v.SetDefault("agent.rag.maxResults", defaultMaxResults)
 }
 
 func DefaultConfigFile() string {

--- a/app/pkg/config/config_test.go
+++ b/app/pkg/config/config_test.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func Test_ConfigDefaultConfig(t *testing.T) {
+	// Create an empty configuration file and run various assertions on it
+	v := viper.New()
+	v.SetConfigFile("/tmp/doesnnotexist.yaml")
+
+	if err := InitViperInstance(v, nil); err != nil {
+		t.Fatalf("Failed to initialize the configuration.")
+	}
+
+	cfg, err := getConfigFromViper(v)
+
+	if err != nil {
+		t.Fatalf("Failed to get config; %+v", err)
+	}
+
+	if cfg.UseRAG() != defaultRagEnabled {
+		t.Errorf("UseRAG want %v; got %v", defaultRagEnabled, cfg.UseRAG())
+	}
+
+	if len(cfg.GetTrainingDirs()) == 0 {
+		t.Errorf("GetTrainingDirs shouldn't return an empty list")
+	}
+}

--- a/app/pkg/config/config_test.go
+++ b/app/pkg/config/config_test.go
@@ -1,31 +1,75 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/viper"
 )
 
 func Test_ConfigDefaultConfig(t *testing.T) {
-	// Create an empty configuration file and run various assertions on it
-	v := viper.New()
-	v.SetConfigFile("/tmp/doesnnotexist.yaml")
-
-	if err := InitViperInstance(v, nil); err != nil {
-		t.Fatalf("Failed to initialize the configuration.")
+	type testCase struct {
+		name             string
+		configFile       string
+		expectedRAG      bool
+		expectedHTTPPort int
 	}
 
-	cfg, err := getConfigFromViper(v)
+	cases := []testCase{
+		{
+			name:             "config-file-does-not-exist",
+			configFile:       "doesnotexist.yaml",
+			expectedRAG:      defaultRagEnabled,
+			expectedHTTPPort: defaultHTTPPort,
+		},
+		{
+			name:             "empty-file",
+			configFile:       "empty.yaml",
+			expectedRAG:      defaultRagEnabled,
+			expectedHTTPPort: defaultHTTPPort,
+		},
+		{
+			name:             "partial",
+			configFile:       "partial.yaml",
+			expectedRAG:      defaultRagEnabled,
+			expectedHTTPPort: defaultHTTPPort,
+		},
+	}
 
+	cwd, err := os.Getwd()
 	if err != nil {
-		t.Fatalf("Failed to get config; %+v", err)
+		t.Fatalf("Failed to get working directory")
 	}
+	tDir := filepath.Join(cwd, "test_data")
 
-	if cfg.UseRAG() != defaultRagEnabled {
-		t.Errorf("UseRAG want %v; got %v", defaultRagEnabled, cfg.UseRAG())
-	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Create an empty configuration file and run various assertions on it
+			v := viper.New()
+			v.SetConfigFile(filepath.Join(tDir, c.configFile))
 
-	if len(cfg.GetTrainingDirs()) == 0 {
-		t.Errorf("GetTrainingDirs shouldn't return an empty list")
+			if err := InitViperInstance(v, nil); err != nil {
+				t.Fatalf("Failed to initialize the configuration.")
+			}
+
+			cfg, err := getConfigFromViper(v)
+
+			if err != nil {
+				t.Fatalf("Failed to get config; %+v", err)
+			}
+
+			if cfg.UseRAG() != c.expectedRAG {
+				t.Errorf("UseRAG want %v; got %v", c.expectedRAG, cfg.UseRAG())
+			}
+
+			if len(cfg.GetTrainingDirs()) == 0 {
+				t.Errorf("GetTrainingDirs shouldn't return an empty list")
+			}
+
+			if cfg.Server.HttpPort != c.expectedHTTPPort {
+				t.Errorf("HttpPort want %d; got %d", c.expectedHTTPPort, cfg.Server.HttpPort)
+			}
+		})
 	}
 }

--- a/app/pkg/config/test_data/partial.yaml
+++ b/app/pkg/config/test_data/partial.yaml
@@ -1,0 +1,38 @@
+apiVersion: ""
+kind: ""
+logging:
+  level: info
+  sinks:
+    - json: true
+      path: gcplogs:///projects/fred-dev/logs/foyle
+    - json: false
+      path: stderr
+server:
+  bindAddress: 0.0.0.0
+  httpMaxReadTimeout: 1m0s
+  httpMaxWriteTimeout: 1m0s
+  cors:
+
+agent:
+  model: claude-3-5-sonnet-20240620
+  modelProvider: anthropic
+  rag:
+    enabled: true
+    maxResults: 3
+  evalMode: false
+openai:
+  apiKeyFile: /Users/red/secrets/openapi.api.key
+  baseURL: ""
+telemetry:
+  honeycomb:
+    apiKeyFile: /Users/fred/secrets/honeycomb.api.key
+eval:
+  gcpServiceAccount: developer@fred-dev.iam.gserviceaccount.com
+learner:
+  logDirs: []
+  exampleDirs:
+    - /Users/fred/.foyle/training
+replicate:
+  apiKeyFile: /Users/fred/replicate/secrets/apikey
+anthropic:
+  apiKeyFile: /Users/fred/secrets/anthropic.key

--- a/app/pkg/server/server.go
+++ b/app/pkg/server/server.go
@@ -409,6 +409,10 @@ func (s *Server) Run() error {
 	trapInterrupt(s)
 
 	log := zapr.NewLogger(zap.L())
+
+	if s.config.Server.HttpPort <= 0 {
+		return errors.New("HTTP port must be a positive integer")
+	}
 	address := fmt.Sprintf("%s:%d", s.config.Server.BindAddress, s.config.Server.HttpPort)
 	log.Info("Starting http server", "address", address)
 


### PR DESCRIPTION
* Fix #249
* The bug was the function UseRAGEnabled was using a hard coded value for the default rather than the constant. As a result, when we recently changed the default to be true it wasn't actually enabled by default.

* Refactor viper processing so its easy to test configuration in a unittest
* We want to be able to create instances of viper using viper.New in the unittest so that we don't have to only use the global viper instance.

* To support that we refactor InitViper into a separate function which takes as an argument *viper.Viper