### PR TITLE
Ensure embeddings matrix is never initialized with zero dimensions

### DIFF
--- a/app/pkg/learn/in_memory_test.go
+++ b/app/pkg/learn/in_memory_test.go
@@ -254,3 +254,38 @@ func Test_UpdateExample(t *testing.T) {
 		})
 	}
 }
+
+func Test_initialNumberOfRows(t *testing.T) {
+	type testCase struct {
+		name        string
+		numExamples int
+		expected    int
+	}
+
+	cases := []testCase{
+		{
+			name:        "edge-case-1",
+			numExamples: 1,
+			expected:    1,
+		},
+		{
+			name:        "small",
+			numExamples: 10,
+			expected:    6,
+		},
+		{
+			name:        "large",
+			numExamples: 100,
+			expected:    66,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := initialNumberOfRows(c.numExamples)
+			if actual != c.expected {
+				t.Errorf("Expected %v but got %v", c.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Because we divide by 1.5; in the edge case were we have 1 example we'd end up rounding down to 0 which will cause problems when we try to initialize a matrix to that size. Fix #248