### PR TITLE
Fix segfault in learner.

### DIFF
--- a/app/pkg/learn/in_memory.go
+++ b/app/pkg/learn/in_memory.go
@@ -200,11 +200,6 @@ func (db *InMemoryExampleDB) loadExamples(ctx context.Context) error {
 			return errors.Wrapf(err, "Failed to match glob %s", glob)
 		}
 
-		// TODO(jeremy): How should we handle there being no examples?
-		if len(matches) == 0 {
-			continue
-		}
-
 		if db.examples == nil {
 			db.examples = make([]*v1alpha1.Example, 0, len(matches))
 		}


### PR DESCRIPTION
When learner is initialized at program startup we want to initialize an empty array because learned examples might arrive during program execution.

If we have a nil matrix to store them we will get a segfault.

Ensuring a matrix is always initialized at startup is one way to solve this.

Follow up to #252 