### PR TITLE
Use gpt4-o-mini by default and filter out </output> tags

### DIFF
--- a/app/pkg/agent/agent.go
+++ b/app/pkg/agent/agent.go
@@ -556,12 +556,23 @@ func postProcessBlocks(blocks []*v1alpha1.Block) ([]*v1alpha1.Block, error) {
 	// Post process the blocks
 	results := make([]*v1alpha1.Block, 0, len(blocks))
 	for _, block := range blocks {
-		if block.GetKind() == v1alpha1.BlockKind_CODE {
-			results = append(results, block)
-			return results, nil
+		if block.GetKind() != v1alpha1.BlockKind_CODE {
+			continue
 		}
+		// The model sometimes returns just the "</output>" tag but inside a coude block.
+		// We want to ignore such blocks.
+		if isOutputTag(block.Contents) {
+			continue
+		}
+		results = append(results, block)
+		return results, nil
 	}
 	return results, nil
+}
+
+func isOutputTag(contents string) bool {
+	trimmed := strings.TrimSpace(contents)
+	return trimmed == "</output>"
 }
 
 // streamState is a structure to keep track of the state for a stream and deal with concurrency

--- a/app/pkg/agent/agent_test.go
+++ b/app/pkg/agent/agent_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/sashabaranov/go-openai"
 
 	parserv1 "github.com/stateful/runme/v3/pkg/api/gen/proto/go/runme/parser/v1"
@@ -336,6 +338,39 @@ func Test_ShouldTrigger(t *testing.T) {
 			actual := shouldTrigger(c.doc, c.selectedIndex)
 			if actual != c.expected {
 				t.Fatalf("Expected %v but got %v", c.expected, actual)
+			}
+		})
+	}
+}
+
+func Test_PostProcessBlocks(t *testing.T) {
+	type testCase struct {
+		name     string
+		blocks   []*v1alpha1.Block
+		expected []*v1alpha1.Block
+	}
+
+	cases := []testCase{
+		{
+			name: "output-tag-in-codeblocks",
+			blocks: []*v1alpha1.Block{
+				{
+					Kind:     v1alpha1.BlockKind_CODE,
+					Contents: "</output>",
+				},
+			},
+			expected: []*v1alpha1.Block{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := postProcessBlocks(c.blocks)
+			if err != nil {
+				t.Fatalf("Error post processing blocks; %v", err)
+			}
+			if d := cmp.Diff(c.expected, actual); d != "" {
+				t.Errorf("Unexpected diff:\n%s", d)
 			}
 		})
 	}

--- a/app/pkg/config/const.go
+++ b/app/pkg/config/const.go
@@ -2,4 +2,4 @@ package config
 
 import "github.com/sashabaranov/go-openai"
 
-const DefaultModel = openai.GPT4o
+const DefaultModel = openai.GPT4oMini


### PR DESCRIPTION
* Use gpt4-o-mini by default to lower costs.
* gpt4-o-mini is more than an order of magnitude cheaper than gpt4-o

  * .15 / million input tokens vs $5 / million input tokens
  * .6 / million output tokens vs $15 / million output tokens

* In the case where OAI can't determine an apporpriate command it often just outputs the output tag </output>. This is sometimes included in a code block so our postprocessing doesn't remove it and turn it into an empty response

* Fix the post-processing to remove this.

Fix #264 