### PR TITLE
Evaluation needs to include the SelectedIndex in the GenerateCellsRequest

### DIFF
--- a/app/pkg/agent/agent.go
+++ b/app/pkg/agent/agent.go
@@ -458,6 +458,7 @@ func (a *Agent) GenerateCells(ctx context.Context, req *connect.Request[v1alpha1
 	agentResp, err := a.Generate(ctx, agentReq)
 	if err != nil {
 		log.Error(err, "Agent.Generate failed")
+		err := errors.Wrapf(err, "Agent.Generate failed; traceId %s", span.SpanContext().TraceID().String())
 		return nil, err
 	}
 

--- a/app/pkg/eval/evaluator.go
+++ b/app/pkg/eval/evaluator.go
@@ -2,11 +2,12 @@ package eval
 
 import (
 	"context"
-	"github.com/go-logr/logr"
 	"os"
 	"path/filepath"
 	"sort"
 	"time"
+
+	"github.com/go-logr/logr"
 
 	"connectrpc.com/connect"
 	"github.com/jlewi/foyle/app/pkg/agent"

--- a/app/pkg/eval/evaluator.go
+++ b/app/pkg/eval/evaluator.go
@@ -285,7 +285,8 @@ func runGenerate(ctx context.Context, result *v1alpha1.EvalResult, client v1alph
 	}
 
 	request := &v1alpha1.GenerateCellsRequest{
-		Notebook: result.Example.GetFullContext().GetNotebook(),
+		Notebook:      result.Example.GetFullContext().GetNotebook(),
+		SelectedIndex: result.Example.GetFullContext().GetSelected(),
 	}
 
 	resp, err := client.GenerateCells(ctx, connect.NewRequest(request))

--- a/app/pkg/eval/judge.go
+++ b/app/pkg/eval/judge.go
@@ -95,6 +95,7 @@ func (j *Judge) Score(ctx context.Context, result *v1alpha1.EvalResult) error {
 	// TODO(jeremy): Use ResponseFormat to enforce JSON output
 	// https://platform.openai.com/docs/guides/structured-outputs/how-to-use?context=without_parse
 	request := openai.ChatCompletionRequest{
+		// TODO(jeremy): Should we use gpt4 mini
 		Model:       openai.GPT4o20240806,
 		Messages:    messages,
 		MaxTokens:   2000,


### PR DESCRIPTION
* In #271 we added a SelectedIndex field to the GenerateCellsRequest to specify which cell in the notebook is active.

* If we don't set it then it ends up defaulting to 0. In which case we end up truncating the notebook to just the first cell and then the evaluation results end up being all wrong.

* Fix a bug in the evaluator runGenerate;  if Agent.GenerateCells returns an error we need to abort execution of runGenerate otherwise we get a panic later in runGenerate when we try to access the message in the response.