### PR TITLE
Don't include output items with mime type stateful.runme/terminal or …

### DIFF
--- a/app/pkg/docs/const.go
+++ b/app/pkg/docs/const.go
@@ -7,4 +7,11 @@ const (
 	// in notebooks. Therefore if we want to be able to convert a markdown document into a document with blocks
 	// then having a unique language for output blocks helps us identify them and properly reencode them.
 	OUTPUTLANG = "output"
+
+	// StatefulRunmeOutputItemsMimeType is the mime type for output items in runme. This will be a JSON object.
+	// See:
+	//    https://github.com/stateful/vscode-runme/blob/3e36b16e3c41ad0fa38f0197f1713135e5edb27b/src/constants.ts#L6
+	//    https://github.com/jlewi/foyle/issues/286
+	StatefulRunmeOutputItemsMimeType = "stateful.runme/output-items"
+	StatefulRunmeTerminalMimeType    = "stateful.runme/terminal"
 )

--- a/app/pkg/docs/converters.go
+++ b/app/pkg/docs/converters.go
@@ -33,6 +33,21 @@ func writeBlockMarkdown(sb *strings.Builder, block *v1alpha1.Block) {
 	// Handle the outputs
 	for _, output := range block.GetOutputs() {
 		for _, oi := range output.Items {
+
+			if oi.GetMime() == StatefulRunmeOutputItemsMimeType || oi.GetMime() == StatefulRunmeTerminalMimeType {
+				// See: https://github.com/jlewi/foyle/issues/286. This output item contains a JSON dictionary
+				// with a bunch of meta information that seems specific to Runme/stateful and not necessarily
+				// relevant as context for AI so we filter it out. The output item we are interested in should
+				// have a mime type of application/vnd.code.notebook.stdout and contain the stdout of the executed
+				// code.
+				//
+				// We use an exclude list for now because Runme is adding additional mime types as it adds custom
+				// renderers. https://github.com/stateful/vscode-runme/blob/3e36b16e3c41ad0fa38f0197f1713135e5edb27b/src/constants.ts#L6
+				// So for now we want to error on including useless data rather than silently dropping useful data.
+				// In the future we may want to revisit that.
+				continue
+			}
+
 			sb.WriteString("```" + OUTPUTLANG + "\n")
 			sb.WriteString(oi.GetTextData())
 			sb.WriteString("\n```\n")

--- a/app/pkg/docs/converters_test.go
+++ b/app/pkg/docs/converters_test.go
@@ -43,6 +43,32 @@ func Test_BlockToMarkdown(t *testing.T) {
 			},
 			expected: "```bash\necho \"something something\"\n```\n```output\nsomething something\n```\n",
 		},
+		{
+			name: "filter-by-mime-type",
+			block: &v1alpha1.Block{
+				Kind:     v1alpha1.BlockKind_CODE,
+				Contents: "echo \"something something\"",
+				Outputs: []*v1alpha1.BlockOutput{
+					{
+						Items: []*v1alpha1.BlockOutputItem{
+							{
+								TextData: "Should be excluded",
+								Mime:     StatefulRunmeOutputItemsMimeType,
+							},
+							{
+								TextData: "Terminal be excluded",
+								Mime:     StatefulRunmeTerminalMimeType,
+							},
+							{
+								TextData: "Should be included",
+								Mime:     "application/vnd.code.notebook.stdout",
+							},
+						},
+					},
+				},
+			},
+			expected: "```bash\necho \"something something\"\n```\n```output\nShould be included\n```\n",
+		},
 	}
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION


* Runme has multiple output items for each cell. It looks like the mime type application/vnd.code.notebook.stdout is usually the one that includes stdout

* Items with stateful.runme/terminal and stateful.runme/output-items in prompt include JSON objects that don't seem relevant to getting help from the AI so we want to filter them out when converting to markdown so they don't confuse the AI.

Related to: https://github.com/jlewi/foyle/issues/286