### PR TITLE
Improve Handling Of Long Outputs

### DIFF
--- a/app/pkg/agent/prompt.tmpl
+++ b/app/pkg/agent/prompt.tmpl
@@ -86,10 +86,11 @@ Google Cloud service account developer@foyle-dev.iam.gserviceaccount.com.
 
 * If the output of a command is really long it will be truncated as indicated by the string "<...stdout was truncated...>"
 * If the truncated output contains critical information to figure out what to do next, you should respond with a
-  suggestion on how to run the command so as to produce just the information you need with less verbosity for example
+  suggestion on how to run the command so as to produce just the information you need with less verbosity
 
-  * For logging or SQL queries add clauses to restrict the output to the rows and fields you need
-  * For large JSON/YAML blobs consider outputting the data to a file and then using tools like jq or yq to read the
+  * If logging or SQL queries leads to truncated output, suggest alternative queries with
+    clauses to restrict the output to the rows and fields you need
+  * If dumping large JSON/YAML blobs leads to truncated output, provide a command to 1) save the data to a file and 2) then use tools like jq or yq to read the
     fields you need
 
 {{if .Examples}}

--- a/app/pkg/agent/prompt.tmpl
+++ b/app/pkg/agent/prompt.tmpl
@@ -84,6 +84,13 @@ Google Cloud service account developer@foyle-dev.iam.gserviceaccount.com.
 </reasoning>
 </example>
 
+* If the output of a command is really long it will be truncated as indicated by the string "<...stdout was truncated...>"
+* If the truncated output contains critical information to figure out what to do next, you should respond with a
+  suggestion on how to run the command so as to produce just the information you need with less verbosity for example
+
+  * For logging or SQL queries add clauses to restrict the output to the rows and fields you need
+  * For large JSON/YAML blobs consider outputting the data to a file and then using tools like jq or yq to read the
+    fields you need
 
 {{if .Examples}}
 Here are a bunch of examples of input documents along with the expected output.

--- a/app/pkg/agent/test_data/examples.txt
+++ b/app/pkg/agent/test_data/examples.txt
@@ -84,6 +84,14 @@ Google Cloud service account developer@foyle-dev.iam.gserviceaccount.com.
 </reasoning>
 </example>
 
+* If the output of a command is really long it will be truncated as indicated by the string "<...stdout was truncated...>"
+* If the truncated output contains critical information to figure out what to do next, you should respond with a
+  suggestion on how to run the command so as to produce just the information you need with less verbosity
+
+  * If logging or SQL queries leads to truncated output, suggest alternative queries with
+    clauses to restrict the output to the rows and fields you need
+  * If dumping large JSON/YAML blobs leads to truncated output, provide a command to 1) save the data to a file and 2) then use tools like jq or yq to read the
+    fields you need
 
 
 Here are a bunch of examples of input documents along with the expected output.

--- a/app/pkg/agent/test_data/no_examples.txt
+++ b/app/pkg/agent/test_data/no_examples.txt
@@ -84,6 +84,14 @@ Google Cloud service account developer@foyle-dev.iam.gserviceaccount.com.
 </reasoning>
 </example>
 
+* If the output of a command is really long it will be truncated as indicated by the string "<...stdout was truncated...>"
+* If the truncated output contains critical information to figure out what to do next, you should respond with a
+  suggestion on how to run the command so as to produce just the information you need with less verbosity
+
+  * If logging or SQL queries leads to truncated output, suggest alternative queries with
+    clauses to restrict the output to the rows and fields you need
+  * If dumping large JSON/YAML blobs leads to truncated output, provide a command to 1) save the data to a file and 2) then use tools like jq or yq to read the
+    fields you need
 
 
 Here's the actual document containing the problem or task to be solved:

--- a/app/pkg/docs/const.go
+++ b/app/pkg/docs/const.go
@@ -14,4 +14,5 @@ const (
 	//    https://github.com/jlewi/foyle/issues/286
 	StatefulRunmeOutputItemsMimeType = "stateful.runme/output-items"
 	StatefulRunmeTerminalMimeType    = "stateful.runme/terminal"
+	VSCodeNotebookStdOutMimeType     = "application/vnd.code.notebook.stdout "
 )

--- a/app/pkg/docs/converters.go
+++ b/app/pkg/docs/converters.go
@@ -88,8 +88,6 @@ func writeBlockMarkdown(sb *strings.Builder, block *v1alpha1.Block, maxLength in
 				// So for now we want to error on including useless data rather than silently dropping useful data.
 				// In the future we may want to revisit that.
 				//
-				// N.B. On the other hand our code for truncating long outputs is based on searching for the mime
-				// type application/vnd.code.notebook.stdout so we need to be careful to ensure that we don't
 				continue
 			}
 

--- a/app/pkg/docs/converters_test.go
+++ b/app/pkg/docs/converters_test.go
@@ -12,9 +12,10 @@ import (
 
 func Test_BlockToMarkdown(t *testing.T) {
 	type testCase struct {
-		name     string
-		block    *v1alpha1.Block
-		expected string
+		name         string
+		block        *v1alpha1.Block
+		maxOutputLen int
+		expected     string
 	}
 
 	testCases := []testCase{
@@ -69,10 +70,28 @@ func Test_BlockToMarkdown(t *testing.T) {
 			},
 			expected: "```bash\necho \"something something\"\n```\n```output\nShould be included\n```\n",
 		},
+		{
+			name: "truncate-output",
+			block: &v1alpha1.Block{
+				Kind:     v1alpha1.BlockKind_CODE,
+				Contents: "echo \"something something\"",
+				Outputs: []*v1alpha1.BlockOutput{
+					{
+						Items: []*v1alpha1.BlockOutputItem{
+							{
+								TextData: "some really long output",
+							},
+						},
+					},
+				},
+			},
+			maxOutputLen: 5,
+			expected:     "```bash\necho \"something something\"\n```\n```output\nsome <...stdout was truncated...>\n```\n",
+		},
 	}
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
-			actual := BlockToMarkdown(c.block)
+			actual := BlockToMarkdown(c.block, c.maxOutputLen)
 			if d := cmp.Diff(c.expected, actual); d != "" {
 				t.Errorf("Unexpected diff:\n%s", d)
 			}

--- a/app/pkg/docs/converters_test.go
+++ b/app/pkg/docs/converters_test.go
@@ -12,10 +12,10 @@ import (
 
 func Test_BlockToMarkdown(t *testing.T) {
 	type testCase struct {
-		name         string
-		block        *v1alpha1.Block
-		maxOutputLen int
-		expected     string
+		name      string
+		block     *v1alpha1.Block
+		maxLength int
+		expected  string
 	}
 
 	testCases := []testCase{
@@ -74,7 +74,7 @@ func Test_BlockToMarkdown(t *testing.T) {
 			name: "truncate-output",
 			block: &v1alpha1.Block{
 				Kind:     v1alpha1.BlockKind_CODE,
-				Contents: "echo \"something something\"",
+				Contents: "echo line1\nline2",
 				Outputs: []*v1alpha1.BlockOutput{
 					{
 						Items: []*v1alpha1.BlockOutputItem{
@@ -85,13 +85,13 @@ func Test_BlockToMarkdown(t *testing.T) {
 					},
 				},
 			},
-			maxOutputLen: 5,
-			expected:     "```bash\necho \"something something\"\n```\n```output\nsome <...stdout was truncated...>\n```\n",
+			maxLength: 10,
+			expected:  "```bash\n<...code was truncated...>\nline2\n```\n```output\nsome r<...stdout was truncated...>\n```\n",
 		},
 	}
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
-			actual := BlockToMarkdown(c.block, c.maxOutputLen)
+			actual := BlockToMarkdown(c.block, c.maxLength)
 			if d := cmp.Diff(c.expected, actual); d != "" {
 				t.Errorf("Unexpected diff:\n%s", d)
 			}

--- a/app/pkg/docs/tailer.go
+++ b/app/pkg/docs/tailer.go
@@ -10,10 +10,6 @@ import (
 	"github.com/jlewi/foyle/protos/go/foyle/v1alpha1"
 )
 
-const (
-	numCodeBlockChars = len("```" + OUTPUTLANG + "\n" + "```\n")
-)
-
 // Tailer is a helper for building a markdown representation of the tail end of a document.
 // It is intended to be stateful and used to iteratively find a suffix of a document that fits within a certain length
 // (i.e. the context length of the model).

--- a/app/pkg/docs/tailer.go
+++ b/app/pkg/docs/tailer.go
@@ -2,7 +2,6 @@ package docs
 
 import (
 	"context"
-	"math"
 	"strings"
 
 	"github.com/jlewi/foyle/app/pkg/logs"
@@ -30,7 +29,6 @@ func NewTailer(ctx context.Context, blocks []*v1alpha1.Block, maxCharLen int) *T
 	log := logs.FromContext(ctx)
 	mdBlocks := make([]string, len(blocks))
 
-	length := 0
 	firstBlock := len(blocks) - 1
 
 	assertion := &v1alpha1.Assertion{
@@ -40,32 +38,17 @@ func NewTailer(ctx context.Context, blocks []*v1alpha1.Block, maxCharLen int) *T
 		Id:     ulid.GenerateID(),
 	}
 
-	// Maximum length of output to include
-	// .5 is just a rough heuristic.
-	maxOutput := math.Floor(.5*float64(maxCharLen)) + 1
-
-	for ; firstBlock >= 0; firstBlock-- {
+	numBlocks := 0
+	for ; firstBlock >= 0 && maxCharLen > 0; firstBlock-- {
 		block := blocks[firstBlock]
-
-		md := BlockToMarkdown(block, int(maxOutput))
-		if length+len(md) > maxCharLen {
-			if length > 0 {
-				// If adding the block would exceed the max length and we already have at least one block then, break
-				break
-			} else {
-				// Since we haven't added any blocks yet, we need to add a truncated version of the last block
-				// N.B. Since the cell output should have been truncated to .5 of the max length, we should
-				// be able to safely assume that tailLines(md, maxCharlen) will include the codeblock for the output
-				// and some of the markup.
-				assertion.Result = v1alpha1.AssertResult_FAILED
-				// N.B. we add len(truncationMessage) and numCodeBlockChars because we don't want them to count
-				// against maxCharLen because we want to make sure we include the opening and closing quotation
-				// marks of the code block. This really only matters for testing with small maxCharLen.
-				// In production maxCharLen should be at least 1K and it shouldn't matter
-				md = tailLines(md, maxCharLen+len(truncationMessage)+numCodeBlockChars)
-			}
+		numBlocks += 1
+		md := BlockToMarkdown(block, maxCharLen)
+		maxCharLen = maxCharLen - len(md)
+		if maxCharLen <= 0 && numBlocks == 1 {
+			// Since this is the first block and its truncated we fail the assertion.
+			assertion.Result = v1alpha1.AssertResult_FAILED
 		}
-		length += len(md)
+
 		mdBlocks[firstBlock] = md
 	}
 

--- a/app/pkg/docs/tailer_test.go
+++ b/app/pkg/docs/tailer_test.go
@@ -55,14 +55,39 @@ func Test_Tailer(t *testing.T) {
 			MaxChars: 12,
 			Expected: "Cell2\nCell3\n",
 		},
+		{
+			name: "truncate-outputs",
+			Doc: &v1alpha1.Doc{
+				Blocks: []*v1alpha1.Block{
+					{
+						Kind:     v1alpha1.BlockKind_CODE,
+						Contents: "Cell1",
+						Outputs: []*v1alpha1.BlockOutput{
+							{
+								Items: []*v1alpha1.BlockOutputItem{
+									{
+										TextData: "Output1\nOutput2\nOutput3",
+										Mime:     VSCodeNotebookStdOutMimeType,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			MaxChars: 12,
+			Expected: "Cell1\n```output\nOutput1<...stdout was truncated...>\n```\n",
+		},
 	}
 
 	for _, c := range cases {
-		tailer := NewTailer(context.Background(), c.Doc.Blocks, c.MaxChars)
-		actual := tailer.Text()
-		if d := cmp.Diff(c.Expected, actual); d != "" {
-			t.Fatalf("Expected text to be %s but got %s; diff:\n%v", c.Expected, tailer.Text(), d)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			tailer := NewTailer(context.Background(), c.Doc.Blocks, c.MaxChars)
+			actual := tailer.Text()
+			if d := cmp.Diff(c.Expected, actual); d != "" {
+				t.Fatalf("Unexpected diff:\n%v", d)
+			}
+		})
 	}
 }
 

--- a/app/pkg/docs/tailer_test.go
+++ b/app/pkg/docs/tailer_test.go
@@ -76,7 +76,7 @@ func Test_Tailer(t *testing.T) {
 				},
 			},
 			MaxChars: 12,
-			Expected: "Cell1\n```output\nOutput1<...stdout was truncated...>\n```\n",
+			Expected: "```bash\nCell1\n```\n```output\nOutput1<...stdout was truncated...>\n```\n",
 		},
 	}
 


### PR DESCRIPTION
# Problem

Cell outputs can be very long. For example, if we run a query (gcloud, SQL, etc...) the output could be very verbose. This output could eat up the entire context allocated for the input document. As a result, we might not have sufficiently meaningful context to prompt the model.

There was another bug in our doc tailer. We were applying character limits to the rendered markdown. We were imposing this by tailing the lines. This could produce invalid markdown. For example, we might end up truncating the document in the middle of a code block so we wouldn't have the opening triple quotes for the code block. We might also include the output of the code block without including the code that it is output for.

# Solution

First, we impose character limits in a way that is aware of cell boundaries. We move truncation into the Block to Markdown conversion. The conversion now takes the maximum length for the output string. The conversion routine then figures out how much to allocate to the contents of the cell and its outputs. This allows truncation to happen in a way that can respect cell boundaries.

Second, if we truncate the code block or output we output a string indicating that the output was truncated. We want the model to know that output was truncated. We update our prompt to tell the LLM to look for truncated output and to potentially deal with this by running commands that will provide less verbose output.



Fix #299