### PR TITLE
Stop forcing cells to be non-interactive

### DIFF
--- a/app/pkg/runme/converters/blocks_to_cells.go
+++ b/app/pkg/runme/converters/blocks_to_cells.go
@@ -14,11 +14,6 @@ func BlocksToCells(blocks []*v1alpha1.Block) ([]*parserv1.Cell, error) {
 		if err != nil {
 			return nil, err
 		}
-		// Set interactive to false because we don't want to render the output as an interactive cell.
-		// This is a hack for https://github.com/jlewi/foyle/issues/286
-		// We should arguably try to learn this
-		// TODO(jeremy): we should use a constant
-		cell.Metadata["interactive"] = "false"
 		cells = append(cells, cell)
 	}
 	return cells, nil

--- a/app/pkg/runme/converters/cells_to_blocks_test.go
+++ b/app/pkg/runme/converters/cells_to_blocks_test.go
@@ -68,6 +68,56 @@ var (
 				},
 			},
 		},
+		{
+			// This test case we don't set interactive explicitly.
+			// It verifies its not getting added
+			name: "no-interactive",
+			Notebook: &parserv1.Notebook{
+				Cells: []*parserv1.Cell{
+					{
+						Metadata: map[string]string{
+							"id": "1234",
+						},
+						Kind:       parserv1.CellKind_CELL_KIND_CODE,
+						LanguageId: "python",
+						Value:      "print('Hello World')",
+						Outputs: []*parserv1.CellOutput{
+							{
+								Items: []*parserv1.CellOutputItem{
+									{
+										Data: []byte("Hello World\n"),
+										Mime: "text/plain",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Doc: &v1alpha1.Doc{
+				Blocks: []*v1alpha1.Block{
+					{
+						Id:       "1234",
+						Language: "python",
+						Contents: "print('Hello World')",
+						Metadata: map[string]string{
+							"id": "1234",
+						},
+						Kind: v1alpha1.BlockKind_CODE,
+						Outputs: []*v1alpha1.BlockOutput{
+							{
+								Items: []*v1alpha1.BlockOutputItem{
+									{
+										TextData: "Hello World\n",
+										Mime:     "text/plain",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 )
 


### PR DESCRIPTION
* Forcing cells to be non-interactive was a temporary fix for the fact that the output wasn't included in Foyle completion requests (#286)

* This is now fixed in the frontend so that the output of interactive cells is included in the requests to Foyle

* We don't want to default to non-interactive cells because non-interactive cells don't show stderr

Related to jlewi/foyle/issues/286