### PR TITLE
Add logging to confirm that stdout isn't empty when triggering on cell execution

### DIFF
--- a/app/pkg/docs/const.go
+++ b/app/pkg/docs/const.go
@@ -14,5 +14,5 @@ const (
 	//    https://github.com/jlewi/foyle/issues/286
 	StatefulRunmeOutputItemsMimeType = "stateful.runme/output-items"
 	StatefulRunmeTerminalMimeType    = "stateful.runme/terminal"
-	VSCodeNotebookStdOutMimeType     = "application/vnd.code.notebook.stdout "
+	VSCodeNotebookStdOutMimeType     = "application/vnd.code.notebook.stdout"
 )

--- a/developer_guides/runme.md
+++ b/developer_guides/runme.md
@@ -55,6 +55,12 @@ Now we can install the extension using the vscode binary
 /Applications/Visual\ Studio\ Code.app/Contents/Resources/app/bin/code --force --install-extension ~/git_vscode-runme/runme-extension.vsix
 ```
 
+```bash {"id":"01JBQ3ZJSS2FXAH4E0CK6SH841"}
+cd ~/git_vscode-runme
+npm run build
+npm run bundle
+```
+
 ```bash {"id":"01JAH5BVWFNHDGGECF7PRE2EE9","interactive":"false"}
 # To check the installed version of the RunMe extension in Visual Studio Code after installation, use the following command:
 BINARY="/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"


### PR DESCRIPTION

* The purpose of this PR is to add logging to confirm that #309 is fixed; i.e. that when triggering on cell execution for interactive (and non interactive cells) the output is included in the request

* This PR adds logging that checks if the selected cell has non-empty stdout if its empty we log a message. The presence of these log messages thus indicates cell execution triggered completion that included no stdout.

* This will include false positives because in certain cases the command may not produce any output.

* With this logging I was unable to reproduce any instances where completion was triggered by cell execution but stdout wasn't included.

* This PR fixes a bug in the mimetype for stdout; there was an extra space. I don't think that actually impacted processing because that constant was only used in unittests before this PR.

* fix #309