### PR TITLE
fix: Correct API endpoint and adjust localhost configuration (Resolves #346)

### DIFF
--- a/docs/content/en/docs/operator-manual/troubleshoot_learning.md
+++ b/docs/content/en/docs/operator-manual/troubleshoot_learning.md
@@ -40,7 +40,7 @@ You can use the session ID to track whether learning occured.
 
 ```bash
 CONTEXTID=01J7S3QZMS5F742JFPWZDCTVRG
-curl -s -X POST https://localhost:8877/foyle.logs.SessionsService/GetSession -H "Content-Type: application/json" -d "{\"contextId\": \"${CONTEXTID}\"}" | jq.
+curl -s -X POST http://localhost:8877/api/GetSession -H "Content-Type: application/json" -d "{\"contextId\": \"${CONTEXTID}\"}" | jq .
 ```
 
 * If this returns not found then no log was created for this sessions and there is a problem with Log Processing

--- a/docs/content/en/docs/operator-manual/troubleshoot_learning.md
+++ b/docs/content/en/docs/operator-manual/troubleshoot_learning.md
@@ -40,7 +40,7 @@ You can use the session ID to track whether learning occured.
 
 ```bash
 CONTEXTID=01J7S3QZMS5F742JFPWZDCTVRG
-curl -s -X POST http://localhost:8877/api/GetSession -H "Content-Type: application/json" -d "{\"contextId\": \"${CONTEXTID}\"}" | jq .
+curl -s -X POST http://localhost:8877/api/foyle.logs.SessionsService/GetSession -H "Content-Type: application/json" -d "{\"contextId\": \"${CONTEXTID}\"}" | jq .
 ```
 
 * If this returns not found then no log was created for this sessions and there is a problem with Log Processing


### PR DESCRIPTION
## Title

fix: Correct API endpoint and adjust localhost configuration (Resolves #346)

##  Description:

This pull request addresses the following issues related to the API call and local development setup:
•	API Endpoint Fix: Updated the endpoint path from foyle.logs.SessionsService/GetSession to api/GetSession for proper routing.
•	jq Syntax Correction: Added a period (.) after jq to ensure JSON output is parsed and displayed correctly.
•	Protocol Adjustment: Replaced https:// with http:// for localhost to avoid unnecessary SSL complications during local testing.

### Before
```
CONTEXTID=01J7S3QZMS5F742JFPWZDCTVRG
curl -s -X POST https://localhost:8877/foyle.logs.SessionsService/GetSession -H "Content-Type: application/json" -d "{\"contextId\": \"${CONTEXTID}\"}" | jq.
```

### After
```
CONTEXTID=01J7S3QZMS5F742JFPWZDCTVRG
curl -s -X POST http://localhost:8877/api/GetSession -H "Content-Type: application/json" -d "{\"contextId\": \"${CONTEXTID}\"}" | jq .
```
Closes Issue: #346